### PR TITLE
Build the WASM core against the system WASI toolchain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "core/wasi-libc"]
-	path = core/wasm/wasi-libc
-	url = git@github.com:CraneStation/wasi-libc.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ minimon.js is a Pokemon Mini emulator: a C++ emulation core compiled to WebAssem
 
 There are no tests and no linter. There is no tsc typecheck step — TypeScript/JSX is transpiled by Vite/esbuild only (the repo is mid-migration from JS to TS).
 
-Building the WASM core requires `clang` with the wasm32 target, `wasm-ld` (falls back to `wasm-ld-10`), python3, and the `core/wasm/wasi-libc` git submodule (checked out and prebuilt; its Makefile invocation is commented out in `core/wasm/Makefile`).
+Building the WASM core uses the system WASI toolchain: `clang` (wasm32 backend), `wasm-ld`, and the wasi-libc sysroot — `apt install lld wasi-libc` on Debian/Ubuntu. A non-standard sysroot location can be passed via `WASI_SYSROOT`/`WASI_LIBDIR` (see `core/wasm/Makefile`).
 
 ## Generated files (do not edit by hand)
 

--- a/core/wasm/Makefile
+++ b/core/wasm/Makefile
@@ -3,13 +3,18 @@ BUILDDIR=obj
 
 SOURCES=$(filter-out $(SRCDIR)/retroarch.cc, $(wildcard $(SRCDIR)/*.cc))
 OBJECTS=$(patsubst $(SRCDIR)/%.cc,$(BUILDDIR)/%.o,$(SOURCES)) $(BUILDDIR)/main.o
-TRACE_OBJECTS=$(patsubst $(SRCDIR)/%.cc,$(BUILDDIR)/%.to,$(SOURCES)) $(BUILDDIR)/main.o
+TRACE_OBJECTS=$(patsubst $(SRCDIR)/%.cc,$(BUILDDIR)/%.to,$(SOURCES)) $(BUILDDIR)/main.to
 TARGET=../../public/libminimon.wasm
 TRACE_TARGET=../../public/libminimon.tracing.wasm
 
-LD=$(if $(shell which wasm-ld),wasm-ld,wasm-ld-10)
+# Uses the system WASI toolchain: clang with the wasm32 backend, wasm-ld
+# from lld, and the wasi-libc sysroot (apt install lld wasi-libc on
+# Debian/Ubuntu; installs to /usr/include/wasm32-wasi + /usr/lib/wasm32-wasi)
+LD=wasm-ld
 DUMP=llvm-dwarfdump
 CC=clang
+WASI_SYSROOT?=/usr
+WASI_LIBDIR?=$(WASI_SYSROOT)/lib/wasm32-wasi
 
 EXPORTS = \
 	--export get_machine \
@@ -22,24 +27,21 @@ EXPORTS = \
 	--export cpu_write \
 	--export get_description
 
-CPPFLAGS = --target=wasm32-wasm -O2 -I. -I../include -std=c++17 --sysroot=./wasi-libc/sysroot -g -Wall
-LDFLAGS = --no-entry --allow-undefined -L ./wasi-libc/sysroot/lib/wasm32-wasi -lc $(EXPORTS)
+CPPFLAGS = --target=wasm32-wasi -O2 -I. -I../include -std=c++17 --sysroot=$(WASI_SYSROOT) -g -Wall
+LDFLAGS = --no-entry --allow-undefined -L $(WASI_LIBDIR) -lc $(EXPORTS)
 
-all: wasi-libc $(BUILDDIR) $(TARGET) $(TRACE_TARGET)
+all: $(BUILDDIR) $(TARGET) $(TRACE_TARGET)
 
 clean:
 	rm -Rf $(TARGET) $(TRACE_TARGET) $(BUILDDIR)
 
-wasi-libc:
-	# make -C wasi-libc
-
 retroarch: $(BUILDDIR)
 	make -f Make.retroarch
 
-$(TARGET): wasi-libc $(OBJECTS)
+$(TARGET): $(OBJECTS)
 	$(LD) $(LDFLAGS) $(OBJECTS) -o $@
 
-$(TRACE_TARGET): wasi-libc $(TRACE_OBJECTS)
+$(TRACE_TARGET): $(TRACE_OBJECTS)
 	$(LD) $(LDFLAGS) $(TRACE_OBJECTS) -o $@
 
 $(BUILDDIR)/%.o: $(SRCDIR)/%.cc ../include/*.h
@@ -57,4 +59,4 @@ $(BUILDDIR)/main.to: main.cc ../include/*.h
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
 
-.PHONY: all clean disassembly wasi-libc
+.PHONY: all clean disassembly


### PR DESCRIPTION
Makes `npm run build` work end-to-end from a fresh checkout.

## Problem

The wasm core build depended on a `wasi-libc` submodule pinned to a 2019 CraneStation commit (that repo moved to the WebAssembly org years ago), and the step that builds its sysroot was commented out in the Makefile — so the core was effectively unbuildable without a pre-existing artifact.

## Changes

- Target `wasm32-wasi` and use the distro WASI toolchain: clang's wasm32 backend, `wasm-ld` from lld, and the system wasi-libc sysroot (`apt install lld wasi-libc` on Debian/Ubuntu). Non-standard locations can be passed with `WASI_SYSROOT`/`WASI_LIBDIR`.
- Remove the dead submodule and `.gitmodules`.
- **Bug fix:** `TRACE_OBJECTS` linked the non-tracing `main.o` into `libminimon.tracing.wasm` even though a `main.to` rule existed — `-D TRACING` never applied to `main.cc`.

## Verification

- `npm run build` runs the full pipeline (table → core → vite); `dist/` contains the deployable site including both wasm binaries
- Both `libminimon.wasm` and `libminimon.tracing.wasm` were instantiated under Node with the same `env` imports the web UI provides: `get_machine`/`get_description` return sane pointers, `cpu_reset`/`cpu_step`/`cpu_advance` execute the BIOS (emulator debug output appears for the known-unimplemented output ports), `cpu_read` returns BIOS bytes
- Compiles warning-free under clang 18 except a pre-existing benign `-Wgnu-variable-sized-type-not-at-end` in `machine.h`

🤖 Generated with [Claude Code](https://claude.com/claude-code)