### PR TITLE
Make CPU register state compiler- and platform-generic

### DIFF
--- a/core/include/blitter.h
+++ b/core/include/blitter.h
@@ -45,7 +45,9 @@ namespace Blitter {
 	struct Overlay {
 		uint8_t framebuffer[8][96];
 		Sprite  oam[24];
-		uint8_t map[];
+		// Remainder of the 4KB RAM window (flexible array members inside
+		// a union arm are not portable C++)
+		uint8_t map[0x1000 - sizeof(uint8_t[8][96]) - sizeof(Sprite[24])];
 	};
 
 	struct State {

--- a/core/include/machine.h
+++ b/core/include/machine.h
@@ -41,42 +41,30 @@ const auto TICK_SPEED	= 1000;
 const auto CPU_SPEED	= 1000000;
 
 namespace CPU {
+	// SC register flag bits
+	const uint8_t SC_Z = 0x01;	// Zero
+	const uint8_t SC_C = 0x02;	// Carry
+	const uint8_t SC_V = 0x04;	// Overflow
+	const uint8_t SC_N = 0x08;	// Negative
+	const uint8_t SC_D = 0x10;	// Decimal mode
+	const uint8_t SC_U = 0x20;	// Unpack (nibble) mode
+	const uint8_t SC_I_MASK = 0xC0;	// Interrupt priority level
+	const int     SC_I_SHIFT = 6;
+
+	// CC register flag bits
+	const uint8_t CC_F0 = 0x01;
+	const uint8_t CC_F1 = 0x02;
+	const uint8_t CC_F2 = 0x04;
+	const uint8_t CC_F3 = 0x08;
+
 	struct State {
-		union {
-			struct {
-				uint8_t sc;
-				uint8_t cc;
-			};
+		uint8_t sc;
+		uint8_t cc;
 
-			struct {
-				unsigned int z:1;
-				unsigned int c:1;
-				unsigned int v:1;
-				unsigned int n:1;
-				unsigned int d:1;
-				unsigned int u:1;
-				unsigned int i:2;
-
-				unsigned int f0:1;
-				unsigned int f1:1;
-				unsigned int f2:1;
-				unsigned int f3:1;
-			} flag;
-		};
-
-		union {
-			struct {
-				uint8_t a;
-				uint8_t b;
-				uint8_t l;
-				uint8_t h;
-			};
-
-			struct {
-				uint16_t ba;
-				uint16_t hl;
-			};
-		};
+		uint8_t a;
+		uint8_t b;
+		uint8_t l;
+		uint8_t h;
 
 		uint16_t pc;
 		uint16_t sp;
@@ -90,6 +78,40 @@ namespace CPU {
 
 		uint8_t cb;
 		uint8_t nb;
+
+		uint16_t ba() const {
+			return (b << 8) | a;
+		}
+
+		void set_ba(uint16_t value) {
+			a = (uint8_t)value;
+			b = value >> 8;
+		}
+
+		uint16_t hl() const {
+			return (h << 8) | l;
+		}
+
+		void set_hl(uint16_t value) {
+			l = (uint8_t)value;
+			h = value >> 8;
+		}
+
+		bool flag(uint8_t mask) const {
+			return (sc & mask) != 0;
+		}
+
+		void set_flag(uint8_t mask, bool value) {
+			sc = value ? (sc | mask) : (sc & ~mask);
+		}
+
+		int priority() const {
+			return (sc & SC_I_MASK) >> SC_I_SHIFT;
+		}
+
+		void set_priority(int value) {
+			sc = (sc & ~SC_I_MASK) | ((value << SC_I_SHIFT) & SC_I_MASK);
+		}
 	};
 };
 

--- a/core/src/irq.cc
+++ b/core/src/irq.cc
@@ -66,13 +66,13 @@ static inline void fire(Machine::State& cpu, Vector irq, uint8_t priority) {
 
 	cpu_clock(cpu, 7);
 	cpu.reg.pc = cpu_read16(cpu, 2 * (int) irq);
-	cpu.reg.flag.i = priority;
+	cpu.reg.set_priority(priority);
 
 	trace_access(cpu, calc_pc(cpu), TRACE_INSTRUCTION | TRACE_BRANCH_TARGET);
 }
 
 void IRQ::manage(Machine::State& cpu) {
-	if (cpu.reg.flag.i < cpu.irq.next_priority) {
+	if (cpu.reg.priority() < cpu.irq.next_priority) {
 		fire(cpu, cpu.irq.next_irq, cpu.irq.next_priority);
 	}
 }

--- a/core/src/operations.cc
+++ b/core/src/operations.cc
@@ -37,7 +37,7 @@ static inline uint32_t calc_absBR(Machine::State& cpu) {
 }
 
 static inline uint32_t calc_absHL(Machine::State& cpu) {
-	return (cpu.reg.ep << 16) | cpu.reg.hl;
+	return (cpu.reg.ep << 16) | cpu.reg.hl();
 }
 
 static inline uint32_t calc_absIX(Machine::State& cpu) {
@@ -74,7 +74,7 @@ static inline uint32_t calc_indIIY(Machine::State& cpu) {
  **/
 
 static inline uint8_t add8(Machine::State& cpu, uint8_t t, uint8_t s, int carry) {
-	if (cpu.reg.flag.u) {
+	if (cpu.reg.flag(CPU::SC_U)) {
 		t <<= 4;
 		s <<= 4;
 		carry <<= 4;
@@ -82,23 +82,23 @@ static inline uint8_t add8(Machine::State& cpu, uint8_t t, uint8_t s, int carry)
 
 	int o = t + s + carry;
 
-	if (cpu.reg.flag.d) {
+	if (cpu.reg.flag(CPU::SC_D)) {
 		int h = (t & 0xF) + (s & 0xF) + carry;
 
 		if (h >= 0x0A) o += 0x6;
 		if (o >= 0xA0) o += 0x60;
 
-		cpu.reg.flag.v = 0;
-		cpu.reg.flag.n = 0;
+		cpu.reg.set_flag(CPU::SC_V, 0);
+		cpu.reg.set_flag(CPU::SC_N, 0);
 	} else {
-		cpu.reg.flag.v = ((t ^ ~s) & (t ^ o) & 0x80) != 0;
-		cpu.reg.flag.n = (o & 0x80) != 0;
+		cpu.reg.set_flag(CPU::SC_V, ((t ^ ~s) & (t ^ o) & 0x80) != 0);
+		cpu.reg.set_flag(CPU::SC_N, (o & 0x80) != 0);
 	}
 
-	cpu.reg.flag.c = o >= 0x100;
-	cpu.reg.flag.z = (o & 0xFF) == 0;
+	cpu.reg.set_flag(CPU::SC_C, o >= 0x100);
+	cpu.reg.set_flag(CPU::SC_Z, (o & 0xFF) == 0);
 
-	if (cpu.reg.flag.u) {
+	if (cpu.reg.flag(CPU::SC_U)) {
 		return (o & 0xF0) >> 4;
 	} else {
 		return o & 0xFF;
@@ -106,7 +106,7 @@ static inline uint8_t add8(Machine::State& cpu, uint8_t t, uint8_t s, int carry)
 }
 
 static inline uint8_t sub8(Machine::State& cpu, uint8_t t, uint8_t s, int carry) {
-	if (cpu.reg.flag.u) {
+	if (cpu.reg.flag(CPU::SC_U)) {
 		t <<= 4;
 		s <<= 4;
 		carry <<= 4;
@@ -114,23 +114,23 @@ static inline uint8_t sub8(Machine::State& cpu, uint8_t t, uint8_t s, int carry)
 
 	int o = t - s - carry;
 
-	if (cpu.reg.flag.d) {
+	if (cpu.reg.flag(CPU::SC_D)) {
 		int h = (t & 0xF) - (s & 0xF) - carry;
 
 		if (h < 0) o -= 0x6;
 		if (o < 0) o -= 0x60;
 
-		cpu.reg.flag.v = 0;
-		cpu.reg.flag.n = 0;
+		cpu.reg.set_flag(CPU::SC_V, 0);
+		cpu.reg.set_flag(CPU::SC_N, 0);
 	} else {
-		cpu.reg.flag.v = ((t ^ s) & (t ^ o) & 0x80) != 0;
-		cpu.reg.flag.n = (o & 0x80) != 0;
+		cpu.reg.set_flag(CPU::SC_V, ((t ^ s) & (t ^ o) & 0x80) != 0);
+		cpu.reg.set_flag(CPU::SC_N, (o & 0x80) != 0);
 	}
 
-	cpu.reg.flag.c = o < 0;
-	cpu.reg.flag.z = (o & 0xFF) == 0;
+	cpu.reg.set_flag(CPU::SC_C, o < 0);
+	cpu.reg.set_flag(CPU::SC_Z, (o & 0xFF) == 0);
 
-	if (cpu.reg.flag.u) {
+	if (cpu.reg.flag(CPU::SC_U)) {
 		return (o & 0xF0) >> 4;
 	} else {
 		return o & 0xFF;
@@ -174,7 +174,7 @@ static inline void op_add8(Machine::State& cpu, uint8_t& t, uint8_t s) {
 }
 
 static inline void op_adc8(Machine::State& cpu, uint8_t& t, uint8_t s) {
-	t = add8(cpu, t, s, cpu.reg.flag.c);
+	t = add8(cpu, t, s, cpu.reg.flag(CPU::SC_C));
 }
 
 static inline void op_sub8(Machine::State& cpu, uint8_t& t, uint8_t s) {
@@ -182,57 +182,57 @@ static inline void op_sub8(Machine::State& cpu, uint8_t& t, uint8_t s) {
 }
 
 static inline void op_sbc8(Machine::State& cpu, uint8_t& t, uint8_t s) {
-	t = sub8(cpu, t, s, cpu.reg.flag.c);
+	t = sub8(cpu, t, s, cpu.reg.flag(CPU::SC_C));
 }
 
 static inline void op_and8(Machine::State& cpu, uint8_t& t, uint8_t s) {
 	uint8_t out = t & s;
-	cpu.reg.flag.z = (out == 0);
-	cpu.reg.flag.n = (out & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, (out == 0));
+	cpu.reg.set_flag(CPU::SC_N, (out & 0x80) != 0);
 	t = out;
 }
 
 static inline void op_or8(Machine::State& cpu, uint8_t& t, uint8_t s) {
 	uint8_t out = t | s;
-	cpu.reg.flag.z = (out == 0);
-	cpu.reg.flag.n = (out & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, (out == 0));
+	cpu.reg.set_flag(CPU::SC_N, (out & 0x80) != 0);
 	t = out;
 }
 
 static inline void op_xor8(Machine::State& cpu, uint8_t& t, uint8_t s) {
 	uint8_t out = t ^ s;
-	cpu.reg.flag.z = (out == 0);
-	cpu.reg.flag.n = (out & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, (out == 0));
+	cpu.reg.set_flag(CPU::SC_N, (out & 0x80) != 0);
 	t = out;
 }
 
 static inline void op_cp8(Machine::State& cpu, uint8_t t, uint8_t s) {
 	int uo = t - s;
 
-	cpu.reg.flag.v = ((t ^ s) & (t ^ uo) & 0x80) != 0;
-	cpu.reg.flag.z = (uo & 0xFF) == 0;
-	cpu.reg.flag.c = uo < 0;
-	cpu.reg.flag.n = (uo & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_V, ((t ^ s) & (t ^ uo) & 0x80) != 0);
+	cpu.reg.set_flag(CPU::SC_Z, (uo & 0xFF) == 0);
+	cpu.reg.set_flag(CPU::SC_C, uo < 0);
+	cpu.reg.set_flag(CPU::SC_N, (uo & 0x80) != 0);
 }
 
 static inline void op_bit8(Machine::State& cpu, uint8_t t, uint8_t s) {
 	auto v = t & s;
-	cpu.reg.flag.z = (v == 0);
-	cpu.reg.flag.n = (v & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, (v == 0));
+	cpu.reg.set_flag(CPU::SC_N, (v & 0x80) != 0);
 }
 
 static inline void op_inc8(Machine::State& cpu, uint8_t& t) {
-	cpu.reg.flag.z = (0 == ++t);
+	cpu.reg.set_flag(CPU::SC_Z, (0 == ++t));
 }
 
 static inline void op_dec8(Machine::State& cpu, uint8_t& t) {
-	cpu.reg.flag.z = (0 == --t);
+	cpu.reg.set_flag(CPU::SC_Z, (0 == --t));
 }
 
 static inline void op_cpl8(Machine::State& cpu, uint8_t& t) {
 	t = ~t;
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = (t & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, (t & 0x80) != 0);
 }
 
 static inline void op_neg8(Machine::State& cpu, uint8_t& t) {
@@ -240,12 +240,12 @@ static inline void op_neg8(Machine::State& cpu, uint8_t& t) {
 }
 
 static inline void inst_mlt(Machine::State& cpu) {
-	cpu.reg.hl = (unsigned int)cpu.reg.l * (unsigned int)cpu.reg.a;
+	cpu.reg.set_hl((unsigned int)cpu.reg.l * (unsigned int)cpu.reg.a);
 
-	cpu.reg.flag.z = cpu.reg.hl == 0;
-	cpu.reg.flag.c = 0;
-	cpu.reg.flag.v = 0;
-	cpu.reg.flag.n = (cpu.reg.hl & 0x8000) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, cpu.reg.hl() == 0);
+	cpu.reg.set_flag(CPU::SC_C, 0);
+	cpu.reg.set_flag(CPU::SC_V, 0);
+	cpu.reg.set_flag(CPU::SC_N, (cpu.reg.hl() & 0x8000) != 0);
 }
 
 static inline void inst_div(Machine::State& cpu) {
@@ -254,19 +254,19 @@ static inline void inst_div(Machine::State& cpu) {
 		return ;
 	}
 
-	int div = cpu.reg.hl / cpu.reg.a;
+	int div = cpu.reg.hl() / cpu.reg.a;
 
-	cpu.reg.flag.c = 0;
+	cpu.reg.set_flag(CPU::SC_C, 0);
 
 	if (div < 0x100) {
-		cpu.reg.h = cpu.reg.hl % cpu.reg.a;
+		cpu.reg.h = cpu.reg.hl() % cpu.reg.a;
 		cpu.reg.l = (uint8_t)div;
-		cpu.reg.flag.n = (div & 0x80) != 0;
-		cpu.reg.flag.z = cpu.reg.l == 0;	// Not sure when this is calculated
-		cpu.reg.flag.v = 0;
+		cpu.reg.set_flag(CPU::SC_N, (div & 0x80) != 0);
+		cpu.reg.set_flag(CPU::SC_Z, cpu.reg.l == 0);	// Not sure when this is calculated
+		cpu.reg.set_flag(CPU::SC_V, 0);
 	} else {
-		cpu.reg.flag.n = 1;
-		cpu.reg.flag.v = 1;
+		cpu.reg.set_flag(CPU::SC_N, 1);
+		cpu.reg.set_flag(CPU::SC_V, 1);
 	}
 }
 
@@ -277,59 +277,59 @@ static inline void inst_div(Machine::State& cpu) {
 static inline void op_add16(Machine::State& cpu, uint16_t& t, uint16_t s) {
 	int uo = t + s;
 
-	cpu.reg.flag.v = ((t ^ ~s) & (t ^ uo) & 0x8000) != 0;
-	cpu.reg.flag.c = uo >= 0x10000;
-	cpu.reg.flag.n = (uo & 0x8000) != 0;
+	cpu.reg.set_flag(CPU::SC_V, ((t ^ ~s) & (t ^ uo) & 0x8000) != 0);
+	cpu.reg.set_flag(CPU::SC_C, uo >= 0x10000);
+	cpu.reg.set_flag(CPU::SC_N, (uo & 0x8000) != 0);
 	t = (uint16_t)uo;
-	cpu.reg.flag.z = t == 0;
+	cpu.reg.set_flag(CPU::SC_Z, t == 0);
 }
 
 static inline void op_adc16(Machine::State& cpu, uint16_t& t, uint16_t s) {
-	int uo = t + s + cpu.reg.flag.c;
+	int uo = t + s + cpu.reg.flag(CPU::SC_C);
 
-	cpu.reg.flag.v = ((t ^ ~s) & (t ^ uo) & 0x8000) != 0;
-	cpu.reg.flag.c = uo >= 0x10000;
-	cpu.reg.flag.n = (uo & 0x8000) != 0;
+	cpu.reg.set_flag(CPU::SC_V, ((t ^ ~s) & (t ^ uo) & 0x8000) != 0);
+	cpu.reg.set_flag(CPU::SC_C, uo >= 0x10000);
+	cpu.reg.set_flag(CPU::SC_N, (uo & 0x8000) != 0);
 	t = (uint16_t)uo;
-	cpu.reg.flag.z = t == 0;
+	cpu.reg.set_flag(CPU::SC_Z, t == 0);
 }
 
 static inline void op_sub16(Machine::State& cpu, uint16_t& t, uint16_t s) {
 	int uo = t - s;
 
-	cpu.reg.flag.v = ((t ^ s) & (t ^ uo) & 0x8000) != 0;
-	cpu.reg.flag.c = uo < 0;
-	cpu.reg.flag.n = (uo & 0x8000) != 0;
+	cpu.reg.set_flag(CPU::SC_V, ((t ^ s) & (t ^ uo) & 0x8000) != 0);
+	cpu.reg.set_flag(CPU::SC_C, uo < 0);
+	cpu.reg.set_flag(CPU::SC_N, (uo & 0x8000) != 0);
 	t = (uint16_t)uo;
-	cpu.reg.flag.z = t == 0;
+	cpu.reg.set_flag(CPU::SC_Z, t == 0);
 }
 
 static inline void op_sbc16(Machine::State& cpu, uint16_t& t, uint16_t s) {
-	int uo = t - s - cpu.reg.flag.c;
+	int uo = t - s - cpu.reg.flag(CPU::SC_C);
 
-	cpu.reg.flag.v = ((t ^ s) & (t ^ uo) & 0x8000) != 0;
-	cpu.reg.flag.c = uo < 0;
-	cpu.reg.flag.n = (uo & 0x8000) != 0;
+	cpu.reg.set_flag(CPU::SC_V, ((t ^ s) & (t ^ uo) & 0x8000) != 0);
+	cpu.reg.set_flag(CPU::SC_C, uo < 0);
+	cpu.reg.set_flag(CPU::SC_N, (uo & 0x8000) != 0);
 	t = (uint16_t)uo;
-	cpu.reg.flag.z = t == 0;
+	cpu.reg.set_flag(CPU::SC_Z, t == 0);
 }
 
 static inline void op_cp16(Machine::State& cpu, uint16_t t, uint16_t s) {
 	int uo = t - s;
 
-	cpu.reg.flag.v = ((t ^ s) & (t ^ uo) & 0x8000) != 0;
-	cpu.reg.flag.c = uo < 0;
-	cpu.reg.flag.n = (uo & 0x8000) != 0;
+	cpu.reg.set_flag(CPU::SC_V, ((t ^ s) & (t ^ uo) & 0x8000) != 0);
+	cpu.reg.set_flag(CPU::SC_C, uo < 0);
+	cpu.reg.set_flag(CPU::SC_N, (uo & 0x8000) != 0);
 	t = (uint16_t)uo;
-	cpu.reg.flag.z = t == 0;
+	cpu.reg.set_flag(CPU::SC_Z, t == 0);
 }
 
 static inline void op_inc16(Machine::State& cpu, uint16_t& t) {
-	cpu.reg.flag.z = (0 == ++t);
+	cpu.reg.set_flag(CPU::SC_Z, (0 == ++t));
 }
 
 static inline void op_dec16(Machine::State& cpu, uint16_t& t) {
-	cpu.reg.flag.z = (0 == --t);
+	cpu.reg.set_flag(CPU::SC_Z, (0 == --t));
 }
 
 /**
@@ -355,63 +355,63 @@ static inline void inst_sep(Machine::State& cpu) {
 
 static inline void op_rl8(Machine::State& cpu, uint8_t& t) {
 	auto old = t;
-	t = (t << 1) | cpu.reg.flag.c;
-	cpu.reg.flag.c = (old & 0x80) != 0;
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = (t & 0x80) != 0;
+	t = (t << 1) | cpu.reg.flag(CPU::SC_C);
+	cpu.reg.set_flag(CPU::SC_C, (old & 0x80) != 0);
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, (t & 0x80) != 0);
 }
 
 static inline void op_rlc8(Machine::State& cpu, uint8_t& t) {
-	cpu.reg.flag.c = (t & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_C, (t & 0x80) != 0);
 	t = (t << 1) | (t >> 7);
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = (t & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, (t & 0x80) != 0);
 }
 
 static inline void op_rr8(Machine::State& cpu, uint8_t& t) {
 	auto old = t;
-	t = (t >> 1) | (cpu.reg.flag.c << 7);
-	cpu.reg.flag.c = (old & 1) != 0;
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = (t & 0x80) != 0;
+	t = (t >> 1) | (cpu.reg.flag(CPU::SC_C) << 7);
+	cpu.reg.set_flag(CPU::SC_C, (old & 1) != 0);
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, (t & 0x80) != 0);
 }
 
 static inline void op_rrc8(Machine::State& cpu, uint8_t& t) {
-	cpu.reg.flag.c = (t & 1) != 0;
+	cpu.reg.set_flag(CPU::SC_C, (t & 1) != 0);
 	t = (t >> 1) | (t << 7);
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = (t & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, (t & 0x80) != 0);
 }
 
 static inline void op_sla8(Machine::State& cpu, uint8_t& t) {
 	auto old = t;
 	t = t << 1;
-	cpu.reg.flag.c = (old & 0x80) != 0;
-	cpu.reg.flag.v = ((t ^ old) & 0x80) != 0;
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = (t & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_C, (old & 0x80) != 0);
+	cpu.reg.set_flag(CPU::SC_V, ((t ^ old) & 0x80) != 0);
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, (t & 0x80) != 0);
 }
 
 static inline void op_sll8(Machine::State& cpu, uint8_t& t) {
-	cpu.reg.flag.c = (t & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_C, (t & 0x80) != 0);
 	t = t << 1;
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = (t & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, (t & 0x80) != 0);
 }
 
 static inline void op_sra8(Machine::State& cpu, uint8_t& t) {
-	cpu.reg.flag.c = (t & 1) != 0;
+	cpu.reg.set_flag(CPU::SC_C, (t & 1) != 0);
 	t = (t >> 1) | (t & 0x80);
-	cpu.reg.flag.v = 0;
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = (t & 0x80) != 0;
+	cpu.reg.set_flag(CPU::SC_V, 0);
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, (t & 0x80) != 0);
 }
 
 static inline void op_srl8(Machine::State& cpu, uint8_t& t) {
-	cpu.reg.flag.c = (t & 1) != 0;
+	cpu.reg.set_flag(CPU::SC_C, (t & 1) != 0);
 	t = t >> 1;
-	cpu.reg.flag.z = (t == 0);
-	cpu.reg.flag.n = 0;
+	cpu.reg.set_flag(CPU::SC_Z, (t == 0));
+	cpu.reg.set_flag(CPU::SC_N, 0);
 }
 
 /**
@@ -432,8 +432,8 @@ static inline void inst_push_ip(Machine::State& cpu) {
 }
 
 static inline void inst_push_all(Machine::State& cpu) {
-	cpu_push16(cpu, cpu.reg.ba);
-	cpu_push16(cpu, cpu.reg.hl);
+	cpu_push16(cpu, cpu.reg.ba());
+	cpu_push16(cpu, cpu.reg.hl());
 	cpu_push16(cpu, cpu.reg.ix);
 	cpu_push16(cpu, cpu.reg.iy);
 	cpu_push8(cpu, cpu.reg.br);
@@ -462,8 +462,8 @@ static inline void inst_pop_all(Machine::State& cpu) {
 	cpu.reg.br = cpu_pop8(cpu);
 	cpu.reg.iy = cpu_pop16(cpu);
 	cpu.reg.ix = cpu_pop16(cpu);
-	cpu.reg.hl = cpu_pop16(cpu);
-	cpu.reg.ba = cpu_pop16(cpu);
+	cpu.reg.set_hl(cpu_pop16(cpu));
+	cpu.reg.set_ba(cpu_pop16(cpu));
 }
 
 static inline void inst_pop_ale(Machine::State& cpu) {
@@ -493,8 +493,8 @@ static inline void op_jrl16(Machine::State& cpu, uint16_t t) {
 static inline void inst_djr_nz_rr(Machine::State& cpu) {
 	int8_t off = cpu_imm8(cpu);
 
-	cpu.reg.flag.z = 0 == --cpu.reg.b;
-	if (!cpu.reg.flag.z) {
+	cpu.reg.set_flag(CPU::SC_Z, 0 == --cpu.reg.b);
+	if (!cpu.reg.flag(CPU::SC_Z)) {
 		cpu.reg.cb = cpu.reg.nb;
 		cpu.reg.pc += off - 1;
 

--- a/core/wasm/main.cc
+++ b/core/wasm/main.cc
@@ -72,8 +72,10 @@ static const StructDecl CpuState = {
 		FIELD( "b", CPU::State,  b,  TYPE_UINT8),
 		FIELD( "l", CPU::State,  l,  TYPE_UINT8),
 		FIELD( "h", CPU::State,  h,  TYPE_UINT8),
-		FIELD("ba", CPU::State, ba, TYPE_UINT16),
-		FIELD("hl", CPU::State, hl, TYPE_UINT16),
+		// WASM linear memory is little-endian by spec, so the BA/HL register
+		// pairs can be exposed as 16-bit views over their component bytes
+		FIELD("ba", CPU::State,  a, TYPE_UINT16),
+		FIELD("hl", CPU::State,  l, TYPE_UINT16),
 		FIELD("pc", CPU::State, pc, TYPE_UINT16),
 		FIELD("sp", CPU::State, sp, TYPE_UINT16),
 		FIELD("ix", CPU::State, ix, TYPE_UINT16),

--- a/tools/table.py
+++ b/tools/table.py
@@ -25,28 +25,28 @@ CSV_LOCATION = os.path.join(os.path.abspath(os.path.dirname(__file__)), 's1c88.c
 op0s, op1s, op2s = [None] * 0x100, [None] * 0x100, [None] * 0x100
 
 CONDITIONS = {
-    'C': 'cpu.reg.flag.c',
-    'NC': '!cpu.reg.flag.c',
-    'Z': 'cpu.reg.flag.z',
-    'NZ': '!cpu.reg.flag.z',
-    'V': 'cpu.reg.flag.v',
-    'NV': '!cpu.reg.flag.v',
-    'M': 'cpu.reg.flag.n',
-    'P': '!cpu.reg.flag.n',
+    'C': 'cpu.reg.flag(CPU::SC_C)',
+    'NC': '!cpu.reg.flag(CPU::SC_C)',
+    'Z': 'cpu.reg.flag(CPU::SC_Z)',
+    'NZ': '!cpu.reg.flag(CPU::SC_Z)',
+    'V': 'cpu.reg.flag(CPU::SC_V)',
+    'NV': '!cpu.reg.flag(CPU::SC_V)',
+    'M': 'cpu.reg.flag(CPU::SC_N)',
+    'P': '!cpu.reg.flag(CPU::SC_N)',
 
-    'LT': 'cpu.reg.flag.n != cpu.reg.flag.v',
-    'LE': '(cpu.reg.flag.n != cpu.reg.flag.v) || cpu.reg.flag.z',
-    'GT': '(cpu.reg.flag.n == cpu.reg.flag.v) && !cpu.reg.flag.z',
-    'GE': 'cpu.reg.flag.n == cpu.reg.flag.v',
+    'LT': 'cpu.reg.flag(CPU::SC_N) != cpu.reg.flag(CPU::SC_V)',
+    'LE': '(cpu.reg.flag(CPU::SC_N) != cpu.reg.flag(CPU::SC_V)) || cpu.reg.flag(CPU::SC_Z)',
+    'GT': '(cpu.reg.flag(CPU::SC_N) == cpu.reg.flag(CPU::SC_V)) && !cpu.reg.flag(CPU::SC_Z)',
+    'GE': 'cpu.reg.flag(CPU::SC_N) == cpu.reg.flag(CPU::SC_V)',
 
-    'F0': 'cpu.reg.flag.f0',
-    'F1': 'cpu.reg.flag.f1',
-    'F2': 'cpu.reg.flag.f2',
-    'F3': 'cpu.reg.flag.f3',
-    'NF0': '!cpu.reg.flag.f0',
-    'NF1': '!cpu.reg.flag.f1',
-    'NF2': '!cpu.reg.flag.f2',
-    'NF3': '!cpu.reg.flag.f3',
+    'F0': '(cpu.reg.cc & CPU::CC_F0) != 0',
+    'F1': '(cpu.reg.cc & CPU::CC_F1) != 0',
+    'F2': '(cpu.reg.cc & CPU::CC_F2) != 0',
+    'F3': '(cpu.reg.cc & CPU::CC_F3) != 0',
+    'NF0': '(cpu.reg.cc & CPU::CC_F0) == 0',
+    'NF1': '(cpu.reg.cc & CPU::CC_F1) == 0',
+    'NF2': '(cpu.reg.cc & CPU::CC_F2) == 0',
+    'NF3': '(cpu.reg.cc & CPU::CC_F3) == 0',
 }
 
 ARGUMENTS = {
@@ -126,11 +126,15 @@ OPERATIONS = {
     'SWAP': (8, 'ReadWrite')
 }
 
+# Virtual register pairs: stored as individual bytes in CPU::State and
+# accessed through ba()/set_ba() style accessors rather than as lvalues
+PAIR_REGS = {'ba', 'hl'}
+
 def get_name(*args):
     return "inst_%s" % '_'.join([arg.lower() for arg in args if arg])
 
 def format_arg(i, siz, mem, ind, nam):
-    if mem:
+    if mem or nam in PAIR_REGS:
         return "data%i" % i
     else:
         return "cpu.reg.%s" % nam
@@ -169,6 +173,11 @@ def format(cycles, op, *args):
                     print ("\tuint%i_t data%i;" % (size, i))
             elif mem:
                 print ("\tconst uint%i_t data%i = cpu_imm%i(cpu);" % (size, i, siz))
+            elif nam in PAIR_REGS:
+                if "Read" in directions[i]:
+                    print ("\tuint%i_t data%i = cpu.reg.%s();" % (siz, i, nam))
+                else:
+                    print ("\tuint%i_t data%i;" % (siz, i))
 
         if condition:
             print ("\tif (!(%s)) {" % CONDITIONS[condition])
@@ -182,6 +191,8 @@ def format(cycles, op, *args):
         for i, (siz, mem, ind, nam) in enumerate(args):
             if ind and "Write" in directions[i]:
                 print ("\tcpu_write%s(cpu, data%i, addr%i);" % (size, i, i))
+            elif nam in PAIR_REGS and "Write" in directions[i]:
+                print ("\tcpu.reg.set_%s(data%i);" % (nam, i))
             if nam in ['sc', 'nb'] and "Write" in directions[i]:
                 block = True
 


### PR DESCRIPTION
First phase of making the core compiler- and platform-generic (no endianness assumptions, no packed bitfields — plain fields and explicit bit math).

## Changes

- **CPU flags**: the `sc`/`cc` ↔ flag-bitfield union is gone. SC and CC are stored as plain bytes — which is also the hardware encoding (`Z=0x01 C=0x02 V=0x04 N=0x08 D=0x10 U=0x20`, interrupt priority in bits 6–7, `F0–F3` in CC) — with `flag()`/`set_flag()`/`priority()` accessors. The old bitfields additionally relied on implementation-defined LSB-first bit allocation.
- **Register pairs**: the `a/b/l/h` ↔ `ba/hl` little-endian union is gone. The byte registers are the storage; `BA`/`HL` are composed with `ba()/set_ba()/hl()/set_hl()`. `tools/table.py` now emits load/store locals for pair operands instead of passing union members by reference.
- **WASM reflection**: still exposes `ba`/`hl` as 16-bit views over the byte pairs — portable in the bridge specifically because WASM linear memory is little-endian by spec. No field names, types, or offsets the UI consumes have changed meaning, so `machine-state.ts` is untouched.
- **GCC compatibility**: `Blitter::Overlay::map` was a flexible array member mid-`Machine::State` (clang-only extension, broke `g++` builds); it now has its true fixed size (remainder of the 4 KB RAM window). Layout unchanged.

## Verification

No tests exist, so this was verified bit-identical with a native (clang, x86-64) build of the core: three ROMs run headless for 30 virtual seconds each, hashing semantic state (register values, RAM, LCD gddram) every virtual second — all 90 hashes identical before/after. Also verified: `npm run core` (both wasm binaries), `npm run check`, and `core/src` now compiles under g++ (the libretro link still fails on a pre-existing missing `link.T`, unrelated).

Note: `Machine::State` shrinks/shifts (the flag union previously padded `CPU::State` to int alignment), so raw-`memcpy` libretro savestates from older builds are invalidated. There is no savestate versioning today.

## Remaining phases (tracked separately)

Peripheral register files (control/input/timers/blitter), guest-memory overlays (sprite OAM bitfields, framebuffer u64 punning), then a final sweep (`__attribute__((packed))` removal, static_asserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)