### PR TITLE
Document the core portability and UI modernization roadmap in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,21 @@ The libretro front-end (`core/libretro/libretro.cc`) wraps the same core; it doe
 - `*.module.less` files are CSS modules (Vite convention); plain `.less`/`.css` (including third-party styles imported from JS) load globally.
 - GLSL shaders import with the `?raw` suffix (`import shader from './x.glsl?raw'`).
 - JSX only parses in `.jsx`/`.tsx` files; there is no type checking in the build.
+
+## Roadmap
+
+Agreed ongoing work, one branch/PR per item (see Workflow). Update this list as items land.
+
+**Core portability** — make the core compiler- and platform-generic: no endianness assumptions, no packed bitfields or type-punning unions, just plain fields and explicit bit math. Done: CPU register state (PR #39). Remaining, in order:
+
+1. Peripheral register files — `control.h`, `input.h`, `timers.h`, `blitter.h` `State`: byte-array ↔ bitfield unions become stored raw bytes with bit-math helpers (timers is the fiddliest: nested 16-bit `preset`/`compare`/`count` unions drive the countdown math).
+2. Guest-memory overlays — `Blitter::Sprite` bitfields over OAM bytes and the `FrameBuffer` `bytes[96][8]` ↔ `uint64_t column[96]` punning in `blitter.cc` become explicit shifts/masks.
+3. Sweep — remove remaining `__attribute__((packed))`, `static_assert` struct sizes, reconcile the wasm reflection tables (and `machine-state.ts`); fix the `offsetof(Timers::State, timer[3])` reflection bug; the libretro link needs its missing `link.T` script.
+
+Verify every phase bit-identical: build the core natively, run ROMs headless, hash semantic state (register values + RAM + LCD gddram — never raw struct bytes) per virtual second, and diff against a pre-change baseline (see PR #39 for the recipe). Note that layout changes invalidate raw-`memcpy` libretro savestates; there is no savestate versioning.
+
+**UI modernization** — done: Vite (PR #35), strict-TS system layer (PR #37), hooks/`useSyncExternalStore` refactor. Remaining:
+
+1. Library swaps — react-virtualized → `@tanstack/react-virtual`; drop Fluent UI (only a handful of controls used, dominates the bundle); rc-dock → dockview.
+2. CI — GitHub Actions on PRs: `npm run check` + Vite build, eventually the wasm core build.
+3. Audio — port `src/system/audio.js` from the deprecated ScriptProcessorNode to an AudioWorklet.


### PR DESCRIPTION
Adds a `## Roadmap` section to CLAUDE.md so the agreed todo list lives on main rather than in any one session's memory:

- **Core portability** (remaining after #39): peripheral register files → guest-memory overlays → packed-attribute/static_assert sweep, plus the bit-identical verification recipe and the savestate-invalidation caveat.
- **UI modernization** (remaining): library swaps, CI, AudioWorklet port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)