### PR TITLE
Replace react-virtualized with @tanstack/react-virtual

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,15 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.14.2",
         "normalize.css": "^8.0.1",
         "rc-dock": "^3.3.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-virtualized": "^9.22.6"
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.31",
         "@types/react-dom": "^18.3.7",
-        "@types/react-virtualized": "^9.22.3",
         "@vitejs/plugin-react": "^4.3.4",
         "less": "^4.2.2",
         "typescript": "^5.7.3",
@@ -1204,6 +1203,33 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
+      "integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
+      "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1282,17 +1308,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-UKRWeBIrECaKhE4O//TSFhlgwntMwyiEIOA7WZoVkr52Jahv0dH6YIOorqc358N2V3oKFclsq5XxPmx2PiYB5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/react": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1396,15 +1411,6 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1432,6 +1438,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1457,16 +1464,6 @@
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
       "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
       "license": "MIT"
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.368",
@@ -1801,15 +1798,6 @@
       "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
       "license": "MIT"
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -1866,23 +1854,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -2129,12 +2100,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2143,24 +2108,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-virtualized": {
-      "version": "9.22.6",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.6.tgz",
-      "integrity": "sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/resize-observer-polyfill": {

--- a/package.json
+++ b/package.json
@@ -24,16 +24,15 @@
   },
   "homepage": "https://github.com/asterick/minimon.js#readme",
   "dependencies": {
+    "@tanstack/react-virtual": "^3.14.2",
     "normalize.css": "^8.0.1",
     "rc-dock": "^3.3.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-virtualized": "^9.22.6"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",
-    "@types/react-virtualized": "^9.22.3",
     "@vitejs/plugin-react": "^4.3.4",
     "less": "^4.2.2",
     "typescript": "^5.7.3",

--- a/src/ui/disassemble/index.tsx
+++ b/src/ui/disassemble/index.tsx
@@ -16,11 +16,11 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-import { useEffect, useState } from "react";
-import { AutoSizer } from 'react-virtualized';
+import { useEffect, useRef, useState } from "react";
 
 import classes from "./style.module.less";
 import { useSystem, useSystemState } from "../context";
+import { useElementSize } from "../use-element-size";
 import { toHex } from "../util";
 
 import { Disassembler } from "../../system/disassemble";
@@ -34,6 +34,9 @@ export default function Disassembly({ follow_pc = true }: DisassemblyProps) {
 	useSystemState();
 
 	const [address, setAddress] = useState(0);
+
+	const container = useRef<HTMLDivElement>(null);
+	const { width, height } = useElementSize(container);
 
 	// Keep the program counter centered in the visible window
 	useEffect(() => {
@@ -67,29 +70,26 @@ export default function Disassembly({ follow_pc = true }: DisassemblyProps) {
 	}
 
 	const target = system.state.cpu.pc;
+	const rowCount = Math.floor(height / 20);
+
+	const disasm = new Disassembler(system);
+	const lines = (rowCount > 0) ? disasm.process(address, rowCount) : [];
 
 	return (
-		<AutoSizer className={classes.disasm}>
-			{({ height, width }) => {
-				const rowCount = Math.floor(height / 20);
-
-				const disasm = new Disassembler(system);
-				const lines = disasm.process(address, rowCount);
-
-				return <table style={{width: `${width}px`, height: `${height}px`}}>
-					<tbody>
-						{
-						lines.map(line =>
-							<tr onClick={() => onClick(line.address)} key={line.address} className={(target == line.address) ? classes['active'] : ''}>
-								<td className={classes["address"]}>{toHex(line.address, 6)}</td>
-								<td>{line.data.map((v, i) => <span className={classes['byte-cell']} key={i}>{toHex(v, 2)}</span>)}</td>
-								<td className={system.breakpoints.indexOf(line.address) >= 0 ? classes['breakpoint'] : ''}>{line.op}</td>
-								<td>{line.args.map((s, i) => <span key={i}>{s}</span>)}</td>
-							</tr>)
-						}
-					</tbody>
-				</table>
-			}}
-		</AutoSizer>
+		<div ref={container} className={classes.disasm} style={{width: '100%', height: '100%', overflow: 'hidden'}}>
+			<table style={{width: `${width}px`, height: `${height}px`}}>
+				<tbody>
+					{
+					lines.map(line =>
+						<tr onClick={() => onClick(line.address)} key={line.address} className={(target == line.address) ? classes['active'] : ''}>
+							<td className={classes["address"]}>{toHex(line.address, 6)}</td>
+							<td>{line.data.map((v, i) => <span className={classes['byte-cell']} key={i}>{toHex(v, 2)}</span>)}</td>
+							<td className={system.breakpoints.indexOf(line.address) >= 0 ? classes['breakpoint'] : ''}>{line.op}</td>
+							<td>{line.args.map((s, i) => <span key={i}>{s}</span>)}</td>
+						</tr>)
+					}
+				</tbody>
+			</table>
+		</div>
 	);
 }

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -28,7 +28,6 @@ import Blitter from "./blitter";
 
 import 'normalize.css/normalize.css';
 import 'rc-dock/dist/rc-dock.css';
-import 'react-virtualized/styles.css';
 import "./style.less";
 
 const screen_tab: TabData = {

--- a/src/ui/memory/index.tsx
+++ b/src/ui/memory/index.tsx
@@ -16,11 +16,12 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-import { useEffect, useRef, useState } from "react";
-import { AutoSizer, List, type ListRowProps } from 'react-virtualized';
+import { useRef, useState } from "react";
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 import classes from "./style.module.less";
 import { useSystem, useSystemState } from "../context";
+import { useElementSize } from "../use-element-size";
 import { toHex } from "../util";
 
 interface Measurements {
@@ -36,16 +37,11 @@ interface MemoryProps {
 
 export default function Memory({ baseAddress, memory: memoryName }: MemoryProps) {
 	const system = useSystem();
-	const version = useSystemState();
+	useSystemState();
 
 	const [measurements, setMeasurements] = useState<Measurements | null>(null);
-	const list = useRef<List>(null);
-
-	// The memory array is mutated in place by the emulation core, so the
-	// virtualized rows must be told to redraw whenever state changes
-	useEffect(() => {
-		list.current?.forceUpdateGrid();
-	}, [version]);
+	const scroller = useRef<HTMLDivElement>(null);
+	const { width } = useElementSize(scroller);
 
 	let memory: Uint8Array;
 
@@ -57,6 +53,18 @@ export default function Memory({ baseAddress, memory: memoryName }: MemoryProps)
 			memory = system.state.gpio.eeprom.data;
 			break;
 	}
+
+	const rowHeight = measurements?.rowHeight ?? 20;
+	const bytesPerRow = measurements
+		? Math.floor((width - measurements.baseWidth) / measurements.elementWidth) - 2
+		: 0;
+	const rowCount = (bytesPerRow > 0) ? Math.ceil(memory.length / bytesPerRow) : 0;
+
+	const virtualizer = useVirtualizer({
+		count: rowCount,
+		getScrollElement: () => scroller.current,
+		estimateSize: () => rowHeight,
+	});
 
 	function measure(r: HTMLDivElement | null) {
 		if (!r) return;
@@ -80,55 +88,51 @@ export default function Memory({ baseAddress, memory: memoryName }: MemoryProps)
 		}
 	}
 
-	return <AutoSizer>
-		{({width, height}) => {
-			/* Measure row / child sizes */
-			if (!measurements) {
-				return <div style={{position: 'absolute', visibility: "hidden"}} ref={measure}>
-					<div className="one-element" style={{display: 'inline-block'}}>
-						<span className={classes.address}>{toHex(0, 6)}</span>
-						<span className={classes.byteCell}>00</span>
-					</div>
-					<div className="two-element" style={{display: 'inline-block'}}>
-						<span className={classes.address}>{toHex(0, 6)}</span>
-						<span className={classes.byteCell}>00</span>
-						<span className={classes.byteCell}>00</span>
-					</div>
-				</div>;
-			}
+	/* Measure row / child sizes */
+	if (!measurements) {
+		return <div ref={scroller} className={classes.memory} style={{ width: '100%', height: '100%' }}>
+			<div style={{position: 'absolute', visibility: "hidden"}} ref={measure}>
+				<div className="one-element" style={{display: 'inline-block'}}>
+					<span className={classes.address}>{toHex(0, 6)}</span>
+					<span className={classes.byteCell}>00</span>
+				</div>
+				<div className="two-element" style={{display: 'inline-block'}}>
+					<span className={classes.address}>{toHex(0, 6)}</span>
+					<span className={classes.byteCell}>00</span>
+					<span className={classes.byteCell}>00</span>
+				</div>
+			</div>
+		</div>;
+	}
 
-			const { baseWidth, elementWidth, rowHeight } = measurements;
+	return (
+		<div ref={scroller} className={classes.memory} style={{ width: '100%', height: '100%', overflowY: 'auto' }}>
+			<div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}>
+				{virtualizer.getVirtualItems().map((row) => {
+					const address = row.index * bytesPerRow;
+					const data = [];
 
-			const bytesPerRow = Math.floor((width - baseWidth) / elementWidth) - 2;
-			if (bytesPerRow <= 0) return null;
+					for (let i = 0, a = address; i < bytesPerRow && a < memory.length; i++, a++)
+						data.push(<span key={a} className={classes.byteCell}>{toHex(memory[a], 2)}</span>);
 
-			function rowRenderer({ key, style, index }: ListRowProps) {
-				const address = index * bytesPerRow;
-				const data = [];
-
-				for (let i = 0, a = address; i < bytesPerRow && a < memory.length; i++, a++)
-					data.push(<span key={a} className={classes.byteCell}>{toHex(memory[a], 2)}</span>);
-
-				return (
-					<div className={classes.dataRow} key={key} style={style}>
-						<span className={classes.address}>{toHex(address + baseAddress, 6)}</span>
-						{ data }
-					</div>
-				)
-			}
-
-			return (
-				<List
-					className={classes.memory}
-					ref={list}
-
-					width={width}
-					height={height}
-					rowCount={Math.ceil(memory.length / bytesPerRow)}
-					rowHeight={rowHeight}
-					rowRenderer={rowRenderer}
-					/>
-			);
-		}}
-	</AutoSizer>
+					return (
+						<div
+							className={classes.dataRow}
+							key={row.key}
+							style={{
+								position: 'absolute',
+								top: 0,
+								left: 0,
+								width: '100%',
+								height: `${row.size}px`,
+								transform: `translateY(${row.start}px)`
+							}}>
+							<span className={classes.address}>{toHex(address + baseAddress, 6)}</span>
+							{ data }
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
 }

--- a/src/ui/use-element-size.ts
+++ b/src/ui/use-element-size.ts
@@ -1,0 +1,32 @@
+import { useLayoutEffect, useState } from "react";
+
+export interface ElementSize {
+	width: number;
+	height: number;
+}
+
+// Tracks an element's client size with a ResizeObserver (replaces
+// react-virtualized's AutoSizer)
+export function useElementSize(ref: React.RefObject<HTMLElement | null>): ElementSize {
+	const [size, setSize] = useState<ElementSize>({ width: 0, height: 0 });
+
+	useLayoutEffect(() => {
+		const element = ref.current;
+		if (!element) return;
+
+		const observer = new ResizeObserver(() => {
+			setSize((previous) => {
+				const width = element.clientWidth;
+				const height = element.clientHeight;
+
+				return (previous.width == width && previous.height == height)
+					? previous : { width, height };
+			});
+		});
+
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, [ref]);
+
+	return size;
+}


### PR DESCRIPTION
## Summary

First of the phase-4 library swaps (see CLAUDE.md roadmap):

- **Memory panel** — `AutoSizer` + `List` → `useVirtualizer` over a plain scroll container. Rows render directly in the component, so the `forceUpdateGrid` workaround for in-place WASM memory mutation goes away: the panel already re-renders on every state version, and the virtualizer just windows the rows.
- **Disassembly panel** — only used `AutoSizer` for sizing; both panels now measure their container with a small ResizeObserver hook (`src/ui/use-element-size.ts`).
- react-virtualized's global stylesheet and `@types/react-virtualized` are gone.

**Bundle: 821 kB → 732 kB (243 kB → 224 kB gzip).** Next swaps (Fluent UI drop, rc-dock → dockview) will follow as their own PRs.

## Verification

Driven headless against the dev server:
- RAM panel: 50 rendered rows at any scroll position; scrolling to `scrollTop=5000` re-windows to address `001B22`; bottom row is `001FEB` (end of RAM)
- EEPROM panel: starts at `000000`, bottom `001FEF` (8 KB part), checked in its own visible pane
- Disassembly: 43 rows from the ResizeObserver-measured height; PC-follow and active-row highlight still work after Step
- No console errors; `npm run check` and `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)