### PR TITLE
Drop Fluent UI in favor of native controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@fluentui/react": "^8.123.0",
         "normalize.css": "^8.0.1",
         "rc-dock": "^3.3.1",
         "react": "^18.3.1",
@@ -17,6 +16,8 @@
         "react-virtualized": "^9.22.6"
       },
       "devDependencies": {
+        "@types/react": "^18.3.31",
+        "@types/react-dom": "^18.3.7",
         "@types/react-virtualized": "^9.22.3",
         "@vitejs/plugin-react": "^4.3.4",
         "less": "^4.2.2",
@@ -757,219 +758,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fluentui/date-time-utilities": {
-      "version": "8.6.11",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.6.11.tgz",
-      "integrity": "sha512-zq49tveFzmzwgaJ73rVvxu9+rqhPBIAJSbevciIQnmvv6dlh2GzZcL14Zevk9QV+q6CWaF6yzvhT11E2TpAv8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/set-version": "^8.2.24",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@fluentui/dom-utilities": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.3.10.tgz",
-      "integrity": "sha512-6WDImiLqTOpkEtfUKSStcTDpzmJfL6ZammomcjawN9xH/8u8G3Hx72CIt2MNck9giw/oUlNLJFdWRAjeP3rmPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/set-version": "^8.2.24",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@fluentui/font-icons-mdl2": {
-      "version": "8.5.73",
-      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.5.73.tgz",
-      "integrity": "sha512-pyR9OE8LJMEVDAUTaTu/rGXaMCsyRqpp5124DhBoFNf6q5kI660IgbzuQadCpyMBEQadYI5/GLkLN7b1Lgou9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/set-version": "^8.2.24",
-        "@fluentui/style-utilities": "^8.15.1",
-        "@fluentui/utilities": "^8.17.2",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@fluentui/foundation-legacy": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.6.6.tgz",
-      "integrity": "sha512-PIcMLOymLvIunp9DrBHUT+dZqwyslKsIOPi+5g/fLU/ySzCg3fs6wQyWHxN3esI5FsSfWi+yCpp+6u5+N00kJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/merge-styles": "^8.6.14",
-        "@fluentui/set-version": "^8.2.24",
-        "@fluentui/style-utilities": "^8.15.1",
-        "@fluentui/utilities": "^8.17.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/keyboard-key": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.4.23.tgz",
-      "integrity": "sha512-9GXeyUqNJUdg5JiQUZeGPiKnRzMRi9YEUn1l9zq6X/imYdMhxHrxpVZS12129cBfgvPyxt9ceJpywSfmLWqlKA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@fluentui/merge-styles": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.14.tgz",
-      "integrity": "sha512-vghuHFAfQgS9WLIIs4kgDOCh/DHd5vGIddP4/bzposhlAVLZR6wUBqldm9AuCdY88r5LyCRMavVJLV+Up3xdvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/set-version": "^8.2.24",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@fluentui/react": {
-      "version": "8.125.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
-      "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/date-time-utilities": "^8.6.11",
-        "@fluentui/font-icons-mdl2": "^8.5.73",
-        "@fluentui/foundation-legacy": "^8.6.6",
-        "@fluentui/merge-styles": "^8.6.14",
-        "@fluentui/react-focus": "^8.10.6",
-        "@fluentui/react-hooks": "^8.10.2",
-        "@fluentui/react-portal-compat-context": "^9.0.15",
-        "@fluentui/react-window-provider": "^2.3.2",
-        "@fluentui/set-version": "^8.2.24",
-        "@fluentui/style-utilities": "^8.15.1",
-        "@fluentui/theme": "^2.7.2",
-        "@fluentui/utilities": "^8.17.2",
-        "@microsoft/load-themed-styles": "^1.10.26",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-focus": {
-      "version": "8.10.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.10.6.tgz",
-      "integrity": "sha512-hMQw7AETttfex3XEAB/XQalJSL8/RgzOdJrL1RPKcrxdkBal0C1MRQ43Bbmw/4WtI0vK0wI4+jHvCIlM0lkodA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-key": "^0.4.23",
-        "@fluentui/merge-styles": "^8.6.14",
-        "@fluentui/set-version": "^8.2.24",
-        "@fluentui/style-utilities": "^8.15.1",
-        "@fluentui/utilities": "^8.17.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-hooks": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.10.2.tgz",
-      "integrity": "sha512-HAd5cX50yKW/LljWlwt+FpSpdS/pNJutk9kMb7FyzxfoGBulL7sj6vX2HvxhSKyJMRKuTstXTdfJmsh22+3W3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-window-provider": "^2.3.2",
-        "@fluentui/set-version": "^8.2.24",
-        "@fluentui/utilities": "^8.17.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-portal-compat-context": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.15.tgz",
-      "integrity": "sha512-DpV+qtFvM3dmH1j8ZD+YcM5vaTvmQPHUAx6tQnnmIoYJWs2R0wU/L5p2EajXy7zSg74jrDbDRxzaziamoOaJdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-window-provider": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.3.2.tgz",
-      "integrity": "sha512-T15zFPIWr9De8hNkapne7YyvcxclyTK2bMXXHZwbWLkVeH/lGHRG0CIy/calNGKa86wuzMJhq8iqFW2W6+EwVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/set-version": "^8.2.24",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/set-version": {
-      "version": "8.2.24",
-      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.2.24.tgz",
-      "integrity": "sha512-8uNi2ThvNgF+6d3q2luFVVdk/wZV0AbRfJ85kkvf2+oSRY+f6QVK0w13vMorNhA5puumKcZniZoAfUF02w7NSg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@fluentui/style-utilities": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.15.1.tgz",
-      "integrity": "sha512-EwjJE7P7XWViNIN+Klm4rFCaADujsfwHB4nzkYeD0zjMokrznsiAvqERxaGZMCRH7tO+DLKITt7kaoQstNLCVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/merge-styles": "^8.6.14",
-        "@fluentui/set-version": "^8.2.24",
-        "@fluentui/theme": "^2.7.2",
-        "@fluentui/utilities": "^8.17.2",
-        "@microsoft/load-themed-styles": "^1.10.26",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@fluentui/theme": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.7.2.tgz",
-      "integrity": "sha512-UXGNfGa/1bLmYrOpmHXdvyc7CzlNSKUQAADweTncbNoMF1DvscWEjPj5kxFgCmOU8wVtvvn4GraNNUSWtNxeeA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/merge-styles": "^8.6.14",
-        "@fluentui/set-version": "^8.2.24",
-        "@fluentui/utilities": "^8.17.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/utilities": {
-      "version": "8.17.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.17.2.tgz",
-      "integrity": "sha512-TmeWVtGN+Lk0mch7tuRcbkeMdrBwltI68fvQbPwcNLo4igFtTInMmjEnVJGa7pBQN5lQAmHYqB9IJI6RZU/t6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/dom-utilities": "^2.3.10",
-        "@fluentui/merge-styles": "^8.6.14",
-        "@fluentui/react-window-provider": "^2.3.2",
-        "@fluentui/set-version": "^8.2.24",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1019,12 +807,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@microsoft/load-themed-styles": {
-      "version": "1.10.295",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.295.tgz",
-      "integrity": "sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==",
-      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -1422,15 +1204,6 @@
         "win32"
       ]
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1491,22 +1264,24 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@types/react": "^19.2.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-virtualized": {
@@ -2551,12 +2326,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,7 @@
     "url": "https://github.com/asterick/minimon.js/issues"
   },
   "homepage": "https://github.com/asterick/minimon.js#readme",
-  "overrides": {
-    "uuid": "^11.1.1"
-  },
   "dependencies": {
-    "@fluentui/react": "^8.123.0",
     "normalize.css": "^8.0.1",
     "rc-dock": "^3.3.1",
     "react": "^18.3.1",
@@ -35,6 +31,8 @@
     "react-virtualized": "^9.22.6"
   },
   "devDependencies": {
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@types/react-virtualized": "^9.22.3",
     "@vitejs/plugin-react": "^4.3.4",
     "less": "^4.2.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,14 +17,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
 import { createRoot } from "react-dom/client";
-import { initializeIcons } from '@fluentui/react/lib/Icons';
 
 import { Minimon } from "./system";
 
 import UI from "./ui";
 import SystemContext from "./ui/context";
-
-initializeIcons();
 
 async function main() {
 	const system = new Minimon("default");

--- a/src/ui/settings/index.tsx
+++ b/src/ui/settings/index.tsx
@@ -17,13 +17,26 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
 import { useRef } from "react";
-import { Toggle } from '@fluentui/react/lib/Toggle';
-import { Stack } from '@fluentui/react/lib/Stack';
-import { DefaultButton } from '@fluentui/react/lib/Button';
 
+import classes from "./style.module.less";
 import { useSystem, useSystemState } from "../context";
 
-const stackTokens = { childrenGap: 10 };
+interface ToggleProps {
+	checked: boolean;
+	onText: string;
+	offText: string;
+	onChange: (checked: boolean) => void;
+}
+
+function Toggle({ checked, onText, offText, onChange }: ToggleProps) {
+	return (
+		<label className={classes.toggle}>
+			<input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+			<span className={classes.track}><span className={classes.thumb} /></span>
+			{checked ? onText : offText}
+		</label>
+	);
+}
 
 export default function Settings() {
 	const system = useSystem();
@@ -39,23 +52,21 @@ export default function Settings() {
 	}
 
 	return (
-		<div style={{ padding: "10px" }}>
+		<div className={classes.settings}>
 			<input ref={fileDialog} type="file" style={{display:'none'}} onChange={load} />
-			<Stack tokens={stackTokens}>
-				<Stack horizontal tokens={stackTokens}>
-					<DefaultButton text="Reset" onClick={() => system.reset()} allowDisabledFocus />
-					<DefaultButton text="Eject" onClick={() => system.eject()} allowDisabledFocus />
-					<DefaultButton text="Step" onClick={() => system.step()} allowDisabledFocus />
-					<DefaultButton text="Load" onClick={() => fileDialog.current?.click()} allowDisabledFocus />
-				</Stack>
+			<div className={classes.row}>
+				<button onClick={() => system.reset()}>Reset</button>
+				<button onClick={() => system.eject()}>Eject</button>
+				<button onClick={() => system.step()}>Step</button>
+				<button onClick={() => fileDialog.current?.click()}>Load</button>
+			</div>
 
-				<Toggle checked={system.running} inlineLabel onText="Running" offText="Stopped" onChange={(_e, checked) => {
-					system.running = !!checked;
-				}} />
-				<Toggle checked={system.tracing} inlineLabel onText="Tracing on" offText="Tracing off" onChange={(_e, checked) => {
-					system.tracing = !!checked;
-				}} />
-			</Stack>
+			<Toggle checked={system.running} onText="Running" offText="Stopped" onChange={(v) => {
+				system.running = v;
+			}} />
+			<Toggle checked={system.tracing} onText="Tracing on" offText="Tracing off" onChange={(v) => {
+				system.tracing = v;
+			}} />
 		</div>
 	);
 }

--- a/src/ui/settings/style.module.less
+++ b/src/ui/settings/style.module.less
@@ -1,0 +1,81 @@
+@import "../settings.less";
+
+.settings {
+	padding: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	align-items: flex-start;
+}
+
+.row {
+	display: flex;
+	gap: 10px;
+}
+
+.settings button {
+	padding: 5px 16px;
+	border: 1px solid @grey-medium;
+	border-radius: 2px;
+	background: @white;
+	font: inherit;
+	cursor: pointer;
+
+	&:hover {
+		background: @grey-light;
+	}
+
+	&:active {
+		background: @original;
+	}
+}
+
+.toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	cursor: pointer;
+	user-select: none;
+
+	input {
+		position: absolute;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	input:focus-visible + .track {
+		outline: 2px solid @blue;
+		outline-offset: 1px;
+	}
+
+	input:checked + .track {
+		background: @blue;
+		border-color: @blue;
+
+		.thumb {
+			left: 21px;
+			background: @white;
+		}
+	}
+}
+
+.track {
+	width: 40px;
+	height: 20px;
+	border: 1px solid @grey-medium;
+	border-radius: 10px;
+	position: relative;
+	background: @white;
+	transition: background 0.1s;
+}
+
+.thumb {
+	position: absolute;
+	top: 3px;
+	left: 3px;
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	background: @grey-medium;
+	transition: left 0.1s, background 0.1s;
+}


### PR DESCRIPTION
## Summary

Second phase-4 library swap. The settings panel was the only Fluent UI consumer — `Toggle`, `Stack`, `DefaultButton` — plus `initializeIcons()` in the entry point:

- Buttons become plain `<button>` elements; the toggles a small checkbox-backed switch component, styled from the existing palette in a new `settings/style.module.less`
- `@types/react` / `@types/react-dom` were arriving transitively through `@fluentui/react` — now direct devDependencies
- The `uuid` override only served Fluent's dependency tree — removed

**Bundle: 821 kB → 580 kB (243 kB → 166 kB gzip).** Independent of #42 (no overlapping files); the dockview swap will follow.

## Verification

Driven headless against the dev server:
- Reset/Eject/Step/Load buttons work (Reset → PC `009A`, Step → `009D`)
- Toggle flips Running↔Stopped by click **and by keyboard (focus + Space)**; emulation starts/stops accordingly
- Tracing toggle still swaps to the tracing wasm build
- No page errors; `npm run check` + `vite build` clean
- Screenshot confirms the switch styling reads like the old Fluent toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)