### PR TITLE
Replace rc-dock with dockview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Three layers, with the C++ core shared between two front-ends:
 
 2. **WASM bridge** — `core/wasm/main.cc` exports the C ABI (`get_machine`, `cpu_advance`, `cpu_step`, `cpu_read/write`, etc.) and, critically, `get_description`: a reflection table (`StructDecl`/`FieldDecl`) describing the entire `Machine::State` memory layout. On the JS side, `src/system/state.ts` parses that reflection blob and builds a live JS object view (DataView/typed arrays directly over WASM memory) — this is how the debugger UI reads/writes registers and hardware state without per-field glue code. The shape of that object is described by the hand-written interfaces in `src/system/machine-state.ts`. When adding fields to machine state that the UI should see, they must be added to the reflection tables in `core/wasm/main.cc` **and** mirrored in `machine-state.ts`.
 
-3. **Web UI** — `src/system/index.ts` (`Minimon` class) fetches the wasm binary (swapping between normal/tracing builds when `.tracing` is toggled), wires keyboard input, WebAudio (`src/system/audio.ts`), breakpoints, and EEPROM/RTC persistence. `src/ui/` is the React debugger: rc-dock window layout + Fluent UI widgets, with panels for the screen (WebGL, shaders in `src/ui/screen/shaders/*.glsl`), disassembly, registers, memory, and blitter/sprite/map viewers. Panels are function components; the system instance comes from React context via `useSystem()` (`src/ui/context.tsx`), and panels subscribe to machine-state changes with `useSystemState()` (`useSyncExternalStore` over a version counter on `Minimon` — machine state is a live mutable view over WASM memory, so the version number serves as the snapshot and `update()` notifies, coalesced to animation frames).
+3. **Web UI** — `src/system/index.ts` (`Minimon` class) fetches the wasm binary (swapping between normal/tracing builds when `.tracing` is toggled), wires keyboard input, WebAudio (`src/system/audio.ts`), breakpoints, and EEPROM/RTC persistence. `src/ui/` is the React debugger: a dockview window layout with native controls, with panels for the screen (WebGL, shaders in `src/ui/screen/shaders/*.glsl`), disassembly, registers, memory (virtualized via `@tanstack/react-virtual`), and blitter/sprite/map viewers. Panels are function components; the system instance comes from React context via `useSystem()` (`src/ui/context.tsx`), and panels subscribe to machine-state changes with `useSystemState()` (`useSyncExternalStore` over a version counter on `Minimon` — machine state is a live mutable view over WASM memory, so the version number serves as the snapshot and `update()` notifies, coalesced to animation frames).
 
 The libretro front-end (`core/libretro/libretro.cc`) wraps the same core; it does not preserve EEPROM or RTC between sessions.
 
@@ -64,8 +64,7 @@ Agreed ongoing work, one branch/PR per item (see Workflow). Update this list as 
 
 Verify every phase bit-identical: build the core natively, run ROMs headless, hash semantic state (register values + RAM + LCD gddram — never raw struct bytes) per virtual second, and diff against a pre-change baseline (see PR #39 for the recipe). Note that layout changes invalidate raw-`memcpy` libretro savestates; there is no savestate versioning.
 
-**UI modernization** — done: Vite (PR #35), strict-TS system layer (PR #37), hooks/`useSyncExternalStore` refactor. Remaining:
+**UI modernization** — done: Vite (PR #35), strict-TS system layer (PR #37), hooks/`useSyncExternalStore` refactor (PR #41), library swaps (`@tanstack/react-virtual` PR #42, native controls PR #43, dockview). Remaining:
 
-1. Library swaps — react-virtualized → `@tanstack/react-virtual`; drop Fluent UI (only a handful of controls used, dominates the bundle); rc-dock → dockview.
-2. CI — GitHub Actions on PRs: `npm run check` + Vite build, eventually the wasm core build.
-3. Audio — port `src/system/audio.ts` from the deprecated ScriptProcessorNode to an AudioWorklet.
+1. CI — GitHub Actions on PRs: `npm run check` + Vite build, eventually the wasm core build.
+2. Audio — port `src/system/audio.ts` from the deprecated ScriptProcessorNode to an AudioWorklet.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.2",
+        "dockview": "^6.6.1",
         "normalize.css": "^8.0.1",
-        "rc-dock": "^3.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -256,15 +256,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1344,12 +1335,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "license": "MIT"
-    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -1405,12 +1390,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1459,10 +1438,22 @@
         }
       }
     },
-    "node_modules/dom-align": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
-      "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
+    "node_modules/dockview": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/dockview/-/dockview-6.6.1.tgz",
+      "integrity": "sha512-vBnxWVk0f665z1Zyx598l/BMUjHD3SK5V4XorxpYGjaSREM8lLc8O6ylgKTtw+ZnCOMYOhcwov9x0ubfFazvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "dockview-core": "^6.6.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/dockview-core": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-6.6.1.tgz",
+      "integrity": "sha512-WuNoO2wl3rGI8MaTuvmfgViek4WafHLD9Kf//Hw69g8TgAHSpAWr6RW15kU6U9vwtQxIi/YBxQNcIA5RzQ46Fw==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -1670,12 +1661,6 @@
         "source-map": "~0.6.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1863,212 +1848,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/rc-align": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.15.tgz",
-      "integrity": "sha512-wqJtVH60pka/nOX7/IspElA8gjPNQKIx/ZqJ6heATCkXpe1Zg4cPVrMD2vC96wjsFFL8WsmhPbx9tdMo1qqlIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "dom-align": "^1.7.0",
-        "rc-util": "^5.26.0",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-dock": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/rc-dock/-/rc-dock-3.3.2.tgz",
-      "integrity": "sha512-0QeoT0QZuu6HC81qTrhncAaQN/RF6pUFJoy/JTXJDrC9LFiEjxMiFdbVa5aqSw4/xmGD/+13mQz92R2dC5PjXw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "classnames": "^2.5.1",
-        "lodash": "^4.17.21",
-        "rc-dropdown": "~4.0.1",
-        "rc-menu": "~9.8.4",
-        "rc-new-window": "^0.1.13",
-        "rc-tabs": "~11.16.1"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
-    "node_modules/rc-dropdown": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.0.1.tgz",
-      "integrity": "sha512-OdpXuOcme1rm45cR0Jzgfl1otzmU4vuBVb+etXM8vcaULGokAKVpKlw8p6xzspG7jGd/XxShvq+N3VNEfk/l5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "classnames": "^2.2.6",
-        "rc-trigger": "^5.3.1",
-        "rc-util": "^5.17.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.11.0",
-        "react-dom": ">=16.11.0"
-      }
-    },
-    "node_modules/rc-menu": {
-      "version": "9.8.4",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.8.4.tgz",
-      "integrity": "sha512-lmw2j8I2fhdIzHmC9ajfImfckt0WDb2KVJJBBRIsxPEw2kGkEfjLMUoB1NgiNT/Q5cC8PdjGOGQjHJIJMwyNMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.4.3",
-        "rc-overflow": "^1.2.8",
-        "rc-trigger": "^5.1.2",
-        "rc-util": "^5.27.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-motion": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
-      "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.44.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-new-window": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/rc-new-window/-/rc-new-window-0.1.13.tgz",
-      "integrity": "sha512-KqANLQVfgNcfs+R4ntpzV5ELyqXMlAUimdSfFHapk2VwsoZX3y+BK2RjFBFb7q865yqAshP87g0PbIPqblKVTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "bowser": "^2.11.0",
-        "classnames": "2.x",
-        "lodash": "^4.17.20"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-overflow": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
-      "integrity": "sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.37.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-resize-observer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
-      "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.44.1",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tabs": {
-      "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.16.1.tgz",
-      "integrity": "sha512-bR7Dap23YyfzZQwtKomhiFEFzZuE7WaKWo+ypNRSGB9PDKSc6tM12VP8LWYkvmmQHthgwP0WRN8nFbSJWuqLYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "2.x",
-        "rc-dropdown": "~4.0.0",
-        "rc-menu": "~9.6.0",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tabs/node_modules/rc-menu": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.6.4.tgz",
-      "integrity": "sha512-6DiNAjxjVIPLZXHffXxxcyE15d4isRL7iQ1ru4MqYDH2Cqc5bW96wZOdMydFtGLyDdnmEQ9jVvdCE9yliGvzkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.4.3",
-        "rc-overflow": "^1.2.0",
-        "rc-trigger": "^5.1.2",
-        "rc-util": "^5.12.0",
-        "shallowequal": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-trigger": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.3.4.tgz",
-      "integrity": "sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "classnames": "^2.2.6",
-        "rc-align": "^4.0.0",
-        "rc-motion": "^2.0.0",
-        "rc-util": "^5.19.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-util": {
-      "version": "5.44.4",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
-      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "react-is": "^18.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -2094,12 +1873,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2109,12 +1882,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.61.1",
@@ -2198,12 +1965,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/asterick/minimon.js#readme",
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.2",
+    "dockview": "^6.6.1",
     "normalize.css": "^8.0.1",
-    "rc-dock": "^3.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -16,8 +16,15 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-import { useRef } from "react";
-import DockLayout, { type LayoutData, type LayoutBase, type TabData } from 'rc-dock'
+import {
+	DockviewReact,
+	DockviewDefaultTab,
+	themeLight,
+	type DockviewApi,
+	type DockviewReadyEvent,
+	type IDockviewPanelProps,
+	type IDockviewPanelHeaderProps,
+} from 'dockview';
 
 import Screen from "./screen";
 import Registers from "./registers";
@@ -27,118 +34,120 @@ import Settings from "./settings";
 import Blitter from "./blitter";
 
 import 'normalize.css/normalize.css';
-import 'rc-dock/dist/rc-dock.css';
+import 'dockview/dist/styles/dockview.css';
 import "./style.less";
 
-const screen_tab: TabData = {
-	id: 'screen',
-	minWidth: 96,
-	minHeight: 64,
-	title: 'Screen',
-	content: <Screen />,
-	closable: false
+const LAYOUT_KEY = "minimon-dockview";
+
+interface MemoryParams {
+	baseAddress: number;
+	memory: 'ram' | 'eeprom';
+}
+
+function MemoryPanel(props: IDockviewPanelProps<MemoryParams>) {
+	return <Memory baseAddress={props.params.baseAddress} memory={props.params.memory} />;
+}
+
+const components = {
+	screen: Screen,
+	settings: Settings,
+	registers: Registers,
+	blitter: Blitter,
+	disassembly: () => <Disassembler />,
+	memory: MemoryPanel,
 };
-const settings_tab: TabData = {id: 'settings', title: 'Settings', content: <Settings />, closable: false };
 
-const blitter_tab: TabData = {id: 'blitter', title: 'Blitter', content: <Blitter />, closable: true };
-const registers_tab: TabData = {id: 'registers', title: 'Registers', content: <Registers />, closable: true };
-const disassembly_tab: TabData = {id: 'disassembly', title: 'Disassembly', content: <Disassembler />, closable: true };
-const memory_tab: TabData = {id: 'memory', title: 'Memory', content: <Memory baseAddress={0x1000} memory='ram' />, closable: false };
-const eeprom_tab: TabData = {id: 'eeprom', title: 'EEPROM', content: <Memory baseAddress={0} memory='eeprom' />, closable: true };
+const tabComponents = {
+	permanent: (props: IDockviewPanelHeaderProps) => <DockviewDefaultTab hideClose {...props} />,
+};
 
-const all_tabs = [
-	screen_tab,
-	registers_tab,
-	disassembly_tab,
-	memory_tab,
-	eeprom_tab,
-	settings_tab,
-	blitter_tab
+// Panels the user can't close; restored as floating windows if a saved
+// layout is missing them
+const REQUIRED_PANELS = [
+	{ id: 'screen', component: 'screen', title: 'Screen' },
+	{ id: 'settings', component: 'settings', title: 'Settings' },
+	{ id: 'memory', component: 'memory', title: 'Memory', params: { baseAddress: 0x1000, memory: 'ram' } },
 ];
 
-const defaultLayout: LayoutData = {
-	dockbox: {
-		mode: 'horizontal',
-		children: [
-			{
-				mode: 'vertical',
-				children: [
-					{
-						tabs: [screen_tab],
-					},
-					{
-						tabs: [settings_tab],
-					},
-					{
-						tabs: [registers_tab, blitter_tab],
-					}
-				]
-			},
-			{
-				mode: 'vertical',
-				children: [
-					{
-						mode: 'vertical',
-						children: [
-							{ tabs: [disassembly_tab, memory_tab, eeprom_tab] }
-						]
-					}
-				]
+function defaultLayout(api: DockviewApi) {
+	api.addPanel({ id: 'screen', component: 'screen', title: 'Screen', tabComponent: 'permanent' });
+	api.addPanel({
+		id: 'disassembly', component: 'disassembly', title: 'Disassembly',
+		position: { referencePanel: 'screen', direction: 'right' }
+	});
+	api.addPanel({
+		id: 'memory', component: 'memory', title: 'Memory', tabComponent: 'permanent',
+		params: { baseAddress: 0x1000, memory: 'ram' },
+		position: { referencePanel: 'disassembly' }
+	});
+	api.addPanel({
+		id: 'eeprom', component: 'memory', title: 'EEPROM',
+		params: { baseAddress: 0, memory: 'eeprom' },
+		position: { referencePanel: 'disassembly' }
+	});
+	api.addPanel({
+		id: 'settings', component: 'settings', title: 'Settings', tabComponent: 'permanent',
+		position: { referencePanel: 'screen', direction: 'below' }
+	});
+	api.addPanel({
+		id: 'registers', component: 'registers', title: 'Registers',
+		position: { referencePanel: 'settings', direction: 'below' }
+	});
+	api.addPanel({
+		id: 'blitter', component: 'blitter', title: 'Blitter',
+		position: { referencePanel: 'registers' }
+	});
 
-			}
-		]
-	}
-};
-
-interface SavedNode {
-	tabs?: { id?: string }[];
-	children?: SavedNode[];
+	api.getPanel('registers')?.api.setActive();
+	api.getPanel('disassembly')?.api.setActive();
 }
 
-function findTabs(node: SavedNode): string[] {
-	if (node.tabs) {
-		return node.tabs.map((t) => t.id).filter((id): id is string => id !== undefined);
-	} else if (node.children) {
-		return node.children.flatMap(findTabs);
+function onReady(event: DockviewReadyEvent) {
+	const api = event.api;
+
+	// The rc-dock layout format is incompatible; drop any stale copy
+	window.localStorage.removeItem("minimon-layout");
+
+	const preserved = window.localStorage.getItem(LAYOUT_KEY);
+	let restored = false;
+
+	if (preserved) {
+		try {
+			api.fromJSON(JSON.parse(preserved));
+			restored = true;
+		} catch (e) {
+			console.warn("Could not restore saved layout", e);
+			api.clear();
+		}
 	}
 
-	return [];
-}
+	if (!restored) {
+		defaultLayout(api);
+	} else {
+		// Re-add any non-closable panels missing from the saved layout
+		REQUIRED_PANELS
+			.filter((panel) => !api.getPanel(panel.id))
+			.forEach((panel, i) => {
+				api.addPanel({
+					...panel,
+					tabComponent: 'permanent',
+					floating: { x: 16 * (i + 1), y: 16 * (i + 1), width: 300, height: 200 }
+				});
+			});
+	}
 
-function preserveLayout(layout: LayoutBase) {
-	window.localStorage.setItem("minimon-layout", JSON.stringify(layout));
+	api.onDidLayoutChange(() => {
+		window.localStorage.setItem(LAYOUT_KEY, JSON.stringify(api.toJSON()));
+	});
 }
 
 export default function UI() {
-	const loaded = useRef(false);
-
-	function reloadLayout(r: DockLayout | null) {
-		if (loaded.current || !r) return;
-
-		loaded.current = true;
-
-		const preserved = window.localStorage.getItem("minimon-layout");
-
-		if (!preserved) return;
-
-		const layout = JSON.parse(preserved);
-
-		/* This will shove tabs not found in arbitrary places */
-		const found_tabs = [layout.dockbox, layout.floatbox, layout.windowbox, layout.maxbox]
-			.filter(Boolean)
-			.flatMap(findTabs);
-		const add = all_tabs.filter((t) => (!t.closable && found_tabs.indexOf(t.id!) < 0));
-
-		layout.floatbox.children.push(... add.map((v, i) => ({ tabs: [v], x: 16*i, y: 16*i, w: 300, h: 200 }) ));
-
-		/* Give the layout to our manager */
-		r.loadLayout(layout);
-	}
-
-	return <DockLayout
-		ref={reloadLayout}
-		defaultLayout={defaultLayout}
-		onLayoutChange={preserveLayout}
-		style={{position: 'absolute', left: 0, top: 0, right: 0, bottom: 0}}
-		/>;
+	return <div style={{position: 'absolute', left: 0, top: 0, right: 0, bottom: 0}}>
+		<DockviewReact
+			components={components}
+			tabComponents={tabComponents}
+			theme={themeLight}
+			onReady={onReady}
+			/>
+	</div>;
 }


### PR DESCRIPTION
## Summary

Final phase-4 library swap — the dock host is now `DockviewReact` (dockview 6.6.1, `themeLight`):

- **Same default arrangement** as before: screen / settings / registers+blitter down the left, disassembly / memory / EEPROM tabbed on the right
- **Layout persistence** moves to a new localStorage key (`minimon-dockview`) — the rc-dock format is incompatible, and any stale `minimon-layout` entry is dropped on load
- **Corrupt saved layouts** fall back to the default layout (`api.clear()` + rebuild)
- **Non-closable panels** (screen, settings, memory) use a `hideClose` tab component; if a saved layout is ever missing one, it's restored as a floating window
- The memory/EEPROM panels share one registered component parameterized through dockview `params`
- CLAUDE.md updated: architecture notes + roadmap (phase 4 library swaps now complete)

Bundle: 491 kB → 540 kB (dockview is larger than rc-dock, but maintained, typed, and the layout engine the roadmap committed to). Net across phase 4: **821 kB → 540 kB (243 → 138 kB gzip)**.

## Verification

Driven headless against the dev server:
- All 7 panels render in the default layout; emulator runs and registers live-update inside dockview panels
- Close buttons present only on closable tabs (Registers/Blitter/Disassembly/EEPROM)
- Closed EEPROM stays closed across reload (persistence)
- Corrupting the saved layout JSON falls back to the full default layout
- Dragging Blitter into the Disassembly group works and the grouping survives reload
- No page errors; `npm run check` + `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)