### PR TITLE
Port audio from ScriptProcessorNode to an AudioWorklet

### DIFF
--- a/src/system/audio.ts
+++ b/src/system/audio.ts
@@ -16,29 +16,65 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-const BUFFER_LENGTH = 1024; // This is the size of an audio clip push
+/*
+ * The processor runs on the audio rendering thread: it keeps a ring
+ * buffer fed by postMessage from the main thread and decays the last
+ * sample towards silence on underrun (same behaviour as the old
+ * ScriptProcessorNode implementation).
+ *
+ * It is shipped as a Blob URL rather than a separate module so the
+ * code needs no bundler-specific worklet handling and behaves the
+ * same under the dev server and `vite build`.
+ */
+const PROCESSOR_SOURCE = `
+class MinimonAudioProcessor extends AudioWorkletProcessor {
+	constructor() {
+		super();
+
+		this.buffer = new Float32Array(4096);
+		this.writeIndex = 0;
+		this.readIndex = 0;
+		this.sample = 0.0;
+
+		this.port.onmessage = (e) => {
+			const f = e.data;
+
+			for (let i = 0; i < f.length; i++) {
+				this.buffer[this.writeIndex++] = f[i];
+				if (this.writeIndex >= this.buffer.length) this.writeIndex = 0;
+			}
+		};
+	}
+
+	process(inputs, outputs) {
+		const audio = outputs[0][0];
+
+		for (let i = 0; i < audio.length; i++) {
+			if (this.readIndex != this.writeIndex) {
+				this.sample = this.buffer[this.readIndex++] * 0.1;
+				if (this.readIndex >= this.buffer.length) this.readIndex = 0;
+			} else {
+				this.sample *= 0.95;
+			}
+			audio[i] = this.sample;
+		}
+
+		return true;
+	}
+}
+
+registerProcessor('minimon-audio', MinimonAudioProcessor);
+`;
 
 export default class Audio {
 	context: AudioContext;
-	node: ScriptProcessorNode;
 
-	private _buffer: Float32Array;
-	private _writeIndex: number;
-	private _readIndex: number;
-	private _sample: number;
+	private _node: AudioWorkletNode | null = null;
 
 	constructor() {
 		this.context = new AudioContext();
 
-		this.node = this.context.createScriptProcessor(BUFFER_LENGTH, 1, 1);
-		this.node.onaudioprocess = this.process.bind(this);
-
-		this._buffer = new Float32Array(BUFFER_LENGTH * 4);
-		this._writeIndex = 0;
-		this._readIndex = 0;
-		this._sample = 0.0;
-
-		this.node.connect(this.context.destination);
+		void this._init();
 
 		// Autoplay policy: an AudioContext created without a user gesture
 		// starts (and stays) suspended. Resume it on the first interaction.
@@ -50,6 +86,23 @@ export default class Audio {
 				document.removeEventListener("keydown", this._resume);
 			}
 		});
+	}
+
+	private async _init(): Promise<void> {
+		const url = URL.createObjectURL(new Blob([PROCESSOR_SOURCE], { type: "application/javascript" }));
+
+		try {
+			await this.context.audioWorklet.addModule(url);
+		} finally {
+			URL.revokeObjectURL(url);
+		}
+
+		this._node = new AudioWorkletNode(this.context, 'minimon-audio', {
+			numberOfInputs: 0,
+			numberOfOutputs: 1,
+			outputChannelCount: [1]
+		});
+		this._node.connect(this.context.destination);
 	}
 
 	private _resume = () => {
@@ -67,24 +120,12 @@ export default class Audio {
 	}
 
 	push(f: Float32Array): void {
-		for (let i = 0; i < f.length; i++) {
-			this._buffer[this._writeIndex++] = f[i];
-			if (this._writeIndex >= this._buffer.length) this._writeIndex = 0;
-		}
-	}
+		// The view aliases WASM memory that the core will overwrite, so
+		// copy the samples out; the copy is transferred, not re-copied.
+		// Pushes before the worklet module resolves are dropped.
+		if (!this._node) return;
 
-	process(e: AudioProcessingEvent): void {
-		const audio = e.outputBuffer.getChannelData(0),
-			length = audio.length;
-
-		for (let i = 0; i < length; i++) {
-			if (this._readIndex != this._writeIndex) {
-				this._sample = this._buffer[this._readIndex++] * 0.1;
-				if (this._readIndex >= this._buffer.length) this._readIndex = 0;
-			} else {
-				this._sample *= 0.95;
-			}
-			audio[i] = this._sample;
-		}
+		const copy = f.slice();
+		this._node.port.postMessage(copy, [copy.buffer]);
 	}
 }


### PR DESCRIPTION
## Summary

Retires the deprecated `ScriptProcessorNode` (the last roadmap audio item):

- The ring buffer + underrun-decay logic moves into an `AudioWorkletProcessor` on the audio rendering thread, byte-for-byte the same semantics (4096-sample ring, 0.1 gain, ×0.95 decay on underrun)
- Main thread feeds it via `port.postMessage` with **transferred** buffers — the pushed `Float32Array` aliases WASM memory and had to be copied out anyway, so the copy is transferred rather than re-serialized
- The processor ships as a **Blob URL**: no bundler-specific worklet handling, identical behavior in dev and `vite build`. (A SharedArrayBuffer ring was rejected — it requires COOP/COEP cross-origin isolation headers that the static deployment doesn't provide.)
- Pushes that arrive before the worklet module resolves (~ms at startup) are dropped, matching the old behavior of an unstarted context
- Autoplay-resume handling from PR #38 is unchanged

## Verification

Headless Chromium with `--autoplay-policy=no-user-gesture-required`:
- Fed a unit sine through `push()` and tapped the node with an `AnalyserNode`: measured RMS **0.0707** — exactly the theoretical 0.1/√2 through the 0.1 gain
- Stopped feeding: output decays to RMS 0.000000 (underrun decay works, no stuck tone)
- App console: **zero** ScriptProcessorNode deprecation warnings (previously logged on every load), no errors
- `npm run check` + `vite build` clean

Side find while verifying (separate PR incoming): `npm run table` truncates `src/system/table.ts` in place, and a watching dev server can cache the empty file if chokidar misses the rewrite — produced a baffling all-panels Disassembly crash. Fix is an atomic write-then-rename in the table script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)