### PR TITLE
Write the generated instruction table atomically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules
 dist
 public
 src/system/table.ts
+src/system/table.ts.tmp
 !public/favicon.png
 table.h

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "core": "cd core; make wasm",
     "retroarch": "cd core/libretro; make test",
-    "table": "python3 ./tools/convert.py > ./src/system/table.ts",
+    "table": "python3 ./tools/convert.py > ./src/system/table.ts.tmp && mv ./src/system/table.ts.tmp ./src/system/table.ts",
     "check": "npm run table; tsc --noEmit",
     "start": "npm run table; vite",
     "build": "npm run table; npm run core; vite build",


### PR DESCRIPTION
## Summary

Found while verifying #45: `npm run table` truncates `src/system/table.ts` in place before the generator writes, so a running Vite dev server can catch — and cache — the empty file. When chokidar (especially on WSL2) misses the follow-up write event, the app keeps serving an **empty instruction table**, and every panel goes down with a baffling `Cannot read properties of undefined` crash in the disassembler.

Generate to `table.ts.tmp` and `mv` into place instead:
- the rename is atomic — watchers see one event with complete content
- a failed generation leaves the previous table intact instead of an empty file
- the temp name is gitignored in case the generator dies mid-run

## Verification

- `npm run table` produces the same 831-line table, no temp file left behind
- `npm run check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)