### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run check
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install WASI toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang lld wasi-libc make
+
+      - run: npm ci
+
+      # npm run build chains its steps with `;`, which would mask a core
+      # build failure; run them individually so each failure fails the job
+      - name: Generate instruction table
+        run: npm run table
+
+      - name: Build WASM core
+        run: npm run core
+
+      - name: Build web UI
+        run: npx vite build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,4 @@ Agreed ongoing work, one branch/PR per item (see Workflow). Update this list as 
 
 Verify every phase bit-identical: build the core natively, run ROMs headless, hash semantic state (register values + RAM + LCD gddram — never raw struct bytes) per virtual second, and diff against a pre-change baseline (see PR #39 for the recipe). Note that layout changes invalidate raw-`memcpy` libretro savestates; there is no savestate versioning.
 
-**UI modernization** — done: Vite (PR #35), strict-TS system layer (PR #37), hooks/`useSyncExternalStore` refactor (PR #41), library swaps (`@tanstack/react-virtual` PR #42, native controls PR #43, dockview). Remaining:
-
-1. CI — GitHub Actions on PRs: `npm run check` + Vite build, eventually the wasm core build.
-2. Audio — port `src/system/audio.ts` from the deprecated ScriptProcessorNode to an AudioWorklet.
+**UI modernization** — COMPLETE: Vite (PR #35), strict-TS system layer (PR #37), hooks/`useSyncExternalStore` refactor (PR #41), library swaps (`@tanstack/react-virtual` PR #42, native controls PR #43, dockview PR #44), AudioWorklet (PR #45), GitHub Actions CI (PR #47). CI runs a type check plus the full build (instruction table, WASM core, Vite) on every PR and push to main — see `.github/workflows/ci.yml`.


### PR DESCRIPTION
## Summary

The final UI-modernization roadmap item — CI on every PR and push to main:

- **Type check** job: `npm ci` + `npm run check`
- **Build** job: WASI toolchain from apt (`clang lld wasi-libc make` — stock Ubuntu 24.04 packages, same recipe as CLAUDE.md), then instruction table → WASM core → production Vite build as **separate steps**, since `npm run build` chains with `;` and would mask a core build failure
- Concurrency group cancels superseded runs on force-push

## Verification

- All four steps run clean locally on the same Ubuntu 24.04 baseline (WSL2)
- The checks on this very PR are the live verification — both jobs should appear below

🤖 Generated with [Claude Code](https://claude.com/claude-code)