### PR TITLE
Make peripheral register files compiler- and platform-generic

### DIFF
--- a/core/include/blitter.h
+++ b/core/include/blitter.h
@@ -50,40 +50,66 @@ namespace Blitter {
 		uint8_t map[0x1000 - sizeof(uint8_t[8][96]) - sizeof(Sprite[24])];
 	};
 
-	struct State {
-		union {
-			uint8_t enables;
-			struct {
-				unsigned invert_map:1;
-				unsigned enable_map:1;
-				unsigned enable_sprites:1;
-				unsigned enable_copy:1;
-				unsigned map_size:2;
-			};
-		};
-		union {
-			uint8_t rate_control;
-			struct {
-				unsigned:1;	// Unknown flag: Possible frame counter enable?
-				unsigned frame_divider:3;
-				unsigned frame_count:4;
-			};
-		};
+	// enables bits (0x2080)
+	const uint8_t ENABLES_INVERT_MAP     = 0x01;
+	const uint8_t ENABLES_MAP            = 0x02;
+	const uint8_t ENABLES_SPRITES        = 0x04;
+	const uint8_t ENABLES_COPY           = 0x08;
+	const uint8_t ENABLES_MAP_SIZE_MASK  = 0x30;
+	const int     ENABLES_MAP_SIZE_SHIFT = 4;
 
-		union {
-			unsigned int map_base;
-			uint8_t map_bytes[3];
-		};
-		union {
-			unsigned int sprite_base;
-			uint8_t sprite_bytes[3];
-		};
+	// rate_control bits (0x2081); bit 0 is an unknown flag (possibly a
+	// frame counter enable), the upper nibble reads back the divider
+	const uint8_t RATE_DIVIDER_MASK  = 0x0E;
+	const int     RATE_DIVIDER_SHIFT = 1;
+
+	struct State {
+		uint8_t enables;
+		uint8_t rate_control;
+
+		// Tile data addresses; the guest programs the low three bytes
+		// through 0x2082-4 / 0x2087-9, the high byte stays zero
+		uint32_t map_base;
+		uint32_t sprite_base;
 
 		uint8_t scroll_x;
 		uint8_t scroll_y;
 
 		// Counters
 		uint8_t divider;
+
+		bool invert_map() const {
+			return (enables & ENABLES_INVERT_MAP) != 0;
+		}
+
+		bool enable_map() const {
+			return (enables & ENABLES_MAP) != 0;
+		}
+
+		bool enable_sprites() const {
+			return (enables & ENABLES_SPRITES) != 0;
+		}
+
+		bool enable_copy() const {
+			return (enables & ENABLES_COPY) != 0;
+		}
+
+		int map_size() const {
+			return (enables & ENABLES_MAP_SIZE_MASK) >> ENABLES_MAP_SIZE_SHIFT;
+		}
+
+		int frame_divider() const {
+			return (rate_control & RATE_DIVIDER_MASK) >> RATE_DIVIDER_SHIFT;
+		}
+
+		static uint8_t base_byte(uint32_t base, int index) {
+			return base >> (8 * index);
+		}
+
+		static void set_base_byte(uint32_t& base, int index, uint8_t value) {
+			const int shift = 8 * index;
+			base = (base & ~(0xFFu << shift)) | ((uint32_t)value << shift);
+		}
 	};
 
 	void reset(Machine::State& cpu);

--- a/core/include/control.h
+++ b/core/include/control.h
@@ -23,13 +23,20 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 namespace Machine { struct State; };
 
 namespace Control {
-	union State {
+	// data[0] bits
+	const uint8_t CTRL_LCD_ENABLED  = 0x01;
+	const uint8_t CTRL_CART_ENABLED = 0x02;
+
+	struct State {
 		uint8_t data[3];
 
-		struct {
-			unsigned lcd_enabled:1;
-			unsigned cart_enabled:1;
-		};
+		bool lcd_enabled() const {
+			return (data[0] & CTRL_LCD_ENABLED) != 0;
+		}
+
+		bool cart_enabled() const {
+			return (data[0] & CTRL_CART_ENABLED) != 0;
+		}
 	};
 
 	void reset(State&);

--- a/core/include/input.h
+++ b/core/include/input.h
@@ -23,21 +23,24 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 namespace Machine { struct State; };
 
 namespace Input {
-	union State {
+	// Register file at 0x2050: bytes 0-1 are the 10-bit interrupt edge
+	// directions, bytes 2-3 the 10-bit pad state (both little-endian),
+	// bytes 4-5 hold the dejitter constants (K00-K03, K04-K07, K10-K11)
+	struct State {
 		uint8_t bytes[6];
 
-		struct __attribute__((packed)) {
-			unsigned interrupt_direction:10;
-			unsigned:6;
-			unsigned input_state:10;
-			unsigned:6;
-			unsigned dejitter_k00_k03:3;
-			unsigned:1;
-			unsigned dejitter_k04_k07:3;
-			unsigned:1;
-			unsigned dejitter_k10_k11:3;
-			unsigned:1;
-		};
+		uint16_t interrupt_direction() const {
+			return bytes[0] | ((bytes[1] & 0x03) << 8);
+		}
+
+		uint16_t input_state() const {
+			return bytes[2] | ((bytes[3] & 0x03) << 8);
+		}
+
+		void set_input_state(uint16_t value) {
+			bytes[2] = (uint8_t)value;
+			bytes[3] = (value >> 8) & 0x03;
+		}
 	};
 
 	void reset(Input::State&);

--- a/core/include/timers.h
+++ b/core/include/timers.h
@@ -23,44 +23,68 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 namespace Machine { struct State; };
 
 namespace Timers {
-	union Timer {
-		uint8_t bytes[8];
+	// lo_flags / hi_flags bits
+	const uint8_t TIMER_INPUT   = 0x01;
+	const uint8_t TIMER_PRESET  = 0x02;
+	const uint8_t TIMER_RUNNING = 0x04;
+	const uint8_t TIMER_OUTPUT  = 0x08;
+	const uint8_t TIMER_MODE16  = 0x80;	// lo_flags only
 
-		struct  __attribute__((packed)) {
-			unsigned lo_input:1;
-			unsigned lo_preset:1;
-			unsigned lo_running:1;
-			unsigned lo_output:1;
-			unsigned:3;
-			unsigned mode16:1;
+	struct Timer {
+		uint8_t lo_flags;
+		uint8_t hi_flags;
 
-			unsigned hi_input:1;
-			unsigned hi_preset:1;
-			unsigned hi_running:1;
-			unsigned hi_output:1;
-			unsigned:4;
+		uint16_t preset;
+		uint16_t compare;
+		uint16_t count;
 
-			union {
-				uint16_t preset;
-				uint8_t preset_bytes[2];
-			};
-			union {
-				uint16_t compare;
-				uint8_t compare_bytes[2];
-			};
-			union {
-				uint16_t count;
-				uint8_t count_bytes[2];
-			};
-		
-			int  lo_clock_ratio;
-			bool lo_clock_ctrl;
-			bool lo_clock_source;
+		int  lo_clock_ratio;
+		bool lo_clock_ctrl;
+		bool lo_clock_source;
 
-			int  hi_clock_ratio;
-			bool hi_clock_ctrl;
-			bool hi_clock_source;
-		};
+		int  hi_clock_ratio;
+		bool hi_clock_ctrl;
+		bool hi_clock_source;
+
+		bool mode16() const {
+			return (lo_flags & TIMER_MODE16) != 0;
+		}
+
+		bool lo_running() const {
+			return (lo_flags & TIMER_RUNNING) != 0;
+		}
+
+		bool hi_running() const {
+			return (hi_flags & TIMER_RUNNING) != 0;
+		}
+
+		// The guest's 8-byte register window (0x2030/0x2038/0x2048):
+		// flag bytes, then preset/compare/count as little-endian pairs
+		uint8_t reg_read(int index) const {
+			switch (index & 7) {
+			case 0:  return lo_flags;
+			case 1:  return hi_flags;
+			case 2:  return (uint8_t)preset;
+			case 3:  return preset >> 8;
+			case 4:  return (uint8_t)compare;
+			case 5:  return compare >> 8;
+			case 6:  return (uint8_t)count;
+			default: return count >> 8;
+			}
+		}
+
+		void reg_write(int index, uint8_t value) {
+			switch (index & 7) {
+			case 0:  lo_flags = value; break;
+			case 1:  hi_flags = value; break;
+			case 2:  preset  = (preset  & 0xFF00) | value; break;
+			case 3:  preset  = (preset  & 0x00FF) | (value << 8); break;
+			case 4:  compare = (compare & 0xFF00) | value; break;
+			case 5:  compare = (compare & 0x00FF) | (value << 8); break;
+			case 6:  count   = (count   & 0xFF00) | value; break;
+			default: count   = (count   & 0x00FF) | (value << 8); break;
+			}
+		}
 	};
 
 	struct State {

--- a/core/src/blitter.cc
+++ b/core/src/blitter.cc
@@ -85,7 +85,7 @@ void Blitter::reset(Machine::State& cpu) {
 
 void Blitter::clock(Machine::State& cpu) {
 	// Framerate divider
-	if (++cpu.blitter.divider < FRAME_DIVIDERS[cpu.blitter.frame_divider]) {
+	if (++cpu.blitter.divider < FRAME_DIVIDERS[cpu.blitter.frame_divider()]) {
 		return ;
 	}
 
@@ -94,8 +94,8 @@ void Blitter::clock(Machine::State& cpu) {
 	// Rendering loop
 	FrameBuffer target;
 
-	if (cpu.blitter.enable_map)	{
-		const MapSize& size = MAP_SIZES[cpu.blitter.map_size];
+	if (cpu.blitter.enable_map())	{
+		const MapSize& size = MAP_SIZES[cpu.blitter.map_size()];
 		int dx = min(cpu.blitter.scroll_x, size.width * 8 - SCREEN_WIDTH);
 		int dy = min(cpu.blitter.scroll_y, size.height * 8 - SCREEN_HEIGHT);
 
@@ -120,7 +120,7 @@ void Blitter::clock(Machine::State& cpu) {
 			}
 		}
 
-		if (cpu.blitter.invert_map) {
+		if (cpu.blitter.invert_map()) {
 			for (int x = 0; x < SCREEN_WIDTH; x++) target.column[x] = ~target.column[x];
 		}
 	} else {
@@ -131,7 +131,7 @@ void Blitter::clock(Machine::State& cpu) {
 		}
 	}
 
-	if (cpu.blitter.enable_sprites) {
+	if (cpu.blitter.enable_sprites()) {
 		for (int i = 23; i >= 0; i--) {
 			Sprite& sprite = cpu.overlay.oam[i];
 		
@@ -189,7 +189,7 @@ void Blitter::clock(Machine::State& cpu) {
 	}
 
 	// Send to LCD
-	if (cpu.blitter.enable_copy) {
+	if (cpu.blitter.enable_copy()) {
 		IRQ::trigger(cpu, IRQ::IRQ_BLT_COPY);
 
 		for (int p = 0, a = 0; p < 8; p++) {
@@ -216,9 +216,9 @@ uint8_t Blitter::read(Machine::State& cpu, uint32_t address) {
 		case 0x2086:
 			return cpu.blitter.scroll_x;
 		case 0x2082 ... 0x2084:
-			return cpu.blitter.map_bytes[address - 0x2082];
+			return Blitter::State::base_byte(cpu.blitter.map_base, address - 0x2082);
 		case 0x2087 ... 0x2089:
-			return cpu.blitter.sprite_bytes[address - 0x2087];
+			return Blitter::State::base_byte(cpu.blitter.sprite_base, address - 0x2087);
 		case 0x208A:
 			return LCD::get_scanline(cpu.lcd);
 
@@ -239,7 +239,7 @@ void Blitter::write(Machine::State& cpu, uint8_t data, uint32_t address) {
 			cpu.blitter.rate_control = data;
 			break ;
 		case 0x2082 ... 0x2084:
-			cpu.blitter.map_bytes[address - 0x2082] = data;
+			Blitter::State::set_base_byte(cpu.blitter.map_base, address - 0x2082, data);
 			break ;
 		case 0x2085:
 			cpu.blitter.scroll_y = data;
@@ -248,7 +248,7 @@ void Blitter::write(Machine::State& cpu, uint8_t data, uint32_t address) {
 			cpu.blitter.scroll_x = data;
 			break ;
 		case 0x2087 ... 0x2089:
-			cpu.blitter.sprite_bytes[address - 0x2087] = data;
+			Blitter::State::set_base_byte(cpu.blitter.sprite_base, address - 0x2087, data);
 			break ;
 	}
 }

--- a/core/src/input.cc
+++ b/core/src/input.cc
@@ -36,13 +36,13 @@ static const IRQ::Vector vectors[] = {
 
 void Input::reset(Input::State& inputs) {
 	memset(&inputs, 0, sizeof(inputs));
-	inputs.input_state = 0b1111111111;
+	inputs.set_input_state(0b1111111111);
 }
 
 void Input::update(Machine::State& cpu, uint16_t value) {
-	uint16_t trigger = (value ^ cpu.input.input_state) & (value ^ cpu.input.interrupt_direction);
+	uint16_t trigger = (value ^ cpu.input.input_state()) & (value ^ cpu.input.interrupt_direction());
 
-	cpu.input.input_state = value;
+	cpu.input.set_input_state(value);
 
 	for (int i = 0; i < 10; i++) {
 		if (trigger & (1 << i)) IRQ::trigger(cpu, vectors[i]);

--- a/core/src/machine.cc
+++ b/core/src/machine.cc
@@ -134,7 +134,7 @@ static inline uint8_t cpu_read_reg(Machine::State& cpu, uint32_t address) {
 		// This should be handled properly
 		return 0b010000;
 	case 0x20FE ... 0x20FF:
-		if (cpu.ctrl.lcd_enabled) {
+		if (cpu.ctrl.lcd_enabled()) {
 			return LCD::read(cpu.lcd, address);
 		} else {
 			return cpu.bus_cap;
@@ -180,7 +180,7 @@ static inline void cpu_write_reg(Machine::State& cpu, uint8_t data, uint32_t add
 		Blitter::write(cpu, data, address);
 		break ;
 	case 0x20FE ... 0x20FF:
-		if (cpu.ctrl.lcd_enabled) {
+		if (cpu.ctrl.lcd_enabled()) {
 			LCD::write(cpu.lcd, data, address);
 		}
 		break ;
@@ -212,7 +212,7 @@ extern "C" uint8_t cpu_read(Machine::State& cpu, uint32_t address) {
 		case 0x2000 ... 0x20FF:
 			return cpu.bus_cap = cpu_read_reg(cpu, address);
 		default:
-			if (cpu.ctrl.cart_enabled) {
+			if (cpu.ctrl.cart_enabled()) {
 				return cpu.bus_cap = cpu_read_cart(cpu, address);		
 			} else {
 				return cpu.bus_cap;
@@ -233,7 +233,7 @@ extern "C" void cpu_write(Machine::State& cpu, uint8_t data, uint32_t address) {
 			cpu_write_reg(cpu, data, address);
 			break ;
 		default:
-			if (cpu.ctrl.cart_enabled) {
+			if (cpu.ctrl.cart_enabled()) {
 				cpu_write_cart(cpu, data, address);
 			}
 			break ;	

--- a/core/src/timers.cc
+++ b/core/src/timers.cc
@@ -87,16 +87,16 @@ static inline void compare(Machine::State& cpu, int vec, int ticks, int compare,
 }
 
 static inline void process_timer(Machine::State& cpu, int osc1, int osc3, Timer& timer, const TimerIRQ& vects) {
-	if (timer.mode16) {
-		if (!timer.lo_running) return ;
+	if (timer.mode16()) {
+		if (!timer.lo_running()) return ;
 
 		int adv = ticks(cpu.timers, timer.lo_clock_source, timer.lo_clock_ctrl, timer.lo_clock_ratio, osc1, osc3);
 		int count = timer.count - adv;
-		
+
 		if (count < 0) {
 			irq(cpu, vects.hi_underflow);
 			do {
-				count += timer.preset + 1;	
+				count += timer.preset + 1;
 			} while (count < 0);
 		}
 
@@ -104,32 +104,32 @@ static inline void process_timer(Machine::State& cpu, int osc1, int osc3, Timer&
 
 		timer.count = count;
 	} else {
-		if (timer.lo_running) {
+		if (timer.lo_running()) {
 			int adv = ticks(cpu.timers, timer.lo_clock_source, timer.lo_clock_ctrl, timer.lo_clock_ratio, osc1, osc3);
-			int count = timer.count_bytes[0] - adv;
+			int count = (timer.count & 0xFF) - adv;
 
 			if (count < 0) {
 				irq(cpu, vects.lo_underflow);
 				do {
-					count += timer.preset_bytes[0] + 1;
+					count += (timer.preset & 0xFF) + 1;
 				} while (count < 0);
 			}
 
-			compare(cpu, vects.lo_compare, adv, timer.compare_bytes[0], timer.preset_bytes[0], timer.count_bytes[0]);
+			compare(cpu, vects.lo_compare, adv, timer.compare & 0xFF, timer.preset & 0xFF, timer.count & 0xFF);
 
-			timer.count_bytes[0] = count;
+			timer.count = (timer.count & 0xFF00) | (uint8_t)count;
 		}
 
-		if (timer.hi_running) {
-			int count = timer.count_bytes[1] - ticks(cpu.timers, timer.hi_clock_source, timer.hi_clock_ctrl, timer.hi_clock_ratio, osc1, osc3);
+		if (timer.hi_running()) {
+			int count = (timer.count >> 8) - ticks(cpu.timers, timer.hi_clock_source, timer.hi_clock_ctrl, timer.hi_clock_ratio, osc1, osc3);
 
 			if (count < 0) {
 				irq(cpu, vects.hi_underflow);
 				do {
-					count += timer.preset_bytes[1] + 1;	
+					count += (timer.preset >> 8) + 1;
 				} while (count < 0);
 			}
-			timer.count_bytes[1] = count;
+			timer.count = (timer.count & 0x00FF) | ((uint8_t)count << 8);
 		}
 	}
 }
@@ -187,15 +187,15 @@ uint8_t Timers::read(Machine::State& cpu, uint32_t address) {
 
 	// Timer 0/1
 	case 0x2030 ... 0x2037:
-		return cpu.timers.timer[0].bytes[address & 0b111];
+		return cpu.timers.timer[0].reg_read(address & 0b111);
 
 	// Timer 2/3
 	case 0x2038 ... 0x203F:
-		return cpu.timers.timer[1].bytes[address & 0b111];
+		return cpu.timers.timer[1].reg_read(address & 0b111);
 
 	// Timer 4/5
 	case 0x2048 ... 0x204F:
-		return cpu.timers.timer[2].bytes[address & 0b111];
+		return cpu.timers.timer[2].reg_read(address & 0b111);
 	
 	default:
 		return 0xCD;
@@ -203,24 +203,22 @@ uint8_t Timers::read(Machine::State& cpu, uint32_t address) {
 }
 
 static inline void setup_timer(Timers::Timer& timer) {
-	if (timer.mode16) {
-		timer.hi_input = 0;
-		timer.hi_preset = 0;
-		timer.hi_running = 0;
+	if (timer.mode16()) {
+		timer.hi_flags &= ~(TIMER_INPUT | TIMER_PRESET | TIMER_RUNNING);
 
-		if (timer.lo_preset) {
+		if (timer.lo_flags & TIMER_PRESET) {
 			timer.count = timer.preset;
-			timer.lo_preset = 0;
+			timer.lo_flags &= ~TIMER_PRESET;
 		}
 	} else {
-		if (timer.lo_preset) {
-			timer.count_bytes[0] = timer.preset_bytes[0];
-			timer.lo_preset = 0;
+		if (timer.lo_flags & TIMER_PRESET) {
+			timer.count = (timer.count & 0xFF00) | (timer.preset & 0x00FF);
+			timer.lo_flags &= ~TIMER_PRESET;
 		}
 
-		if (timer.hi_preset) {
-			timer.count_bytes[1] = timer.preset_bytes[1];
-			timer.hi_preset = 0;
+		if (timer.hi_flags & TIMER_PRESET) {
+			timer.count = (timer.count & 0x00FF) | (timer.preset & 0xFF00);
+			timer.hi_flags &= ~TIMER_PRESET;
 		}
 	}
 }
@@ -264,29 +262,29 @@ void Timers::write(Machine::State& cpu, uint8_t data, uint32_t address) {
 
 	// Timer 0/1
 	case 0x2030 ... 0x2031:
-		cpu.timers.timer[0].bytes[address & 0b111] = data & TIMER_MASK[address & 0b111];
+		cpu.timers.timer[0].reg_write(address & 0b111, data & TIMER_MASK[address & 0b111]);
 		setup_timer(cpu.timers.timer[0]);
 		break ;
 	case 0x2032 ... 0x2035:
-		cpu.timers.timer[0].bytes[address & 0b111] = data & TIMER_MASK[address & 0b111];
+		cpu.timers.timer[0].reg_write(address & 0b111, data & TIMER_MASK[address & 0b111]);
 		break ;
 
 	// Timer 2/3
 	case 0x2038 ... 0x2039:
-		cpu.timers.timer[1].bytes[address & 0b111] = data & TIMER_MASK[address & 0b111];
+		cpu.timers.timer[1].reg_write(address & 0b111, data & TIMER_MASK[address & 0b111]);
 		setup_timer(cpu.timers.timer[1]);
 		break ;
 	case 0x203A ... 0x203D:
-		cpu.timers.timer[1].bytes[address & 0b111] = data & TIMER_MASK[address & 0b111];
+		cpu.timers.timer[1].reg_write(address & 0b111, data & TIMER_MASK[address & 0b111]);
 		break ;
 
 	// Timer 4/5
 	case 0x2048 ... 0x2049:
-		cpu.timers.timer[2].bytes[address & 0b111] = data & TIMER_MASK[address & 0b111];
+		cpu.timers.timer[2].reg_write(address & 0b111, data & TIMER_MASK[address & 0b111]);
 		setup_timer(cpu.timers.timer[2]);
 		break ;
 	case 0x204A ... 0x204D:
-		cpu.timers.timer[2].bytes[address & 0b111] = data & TIMER_MASK[address & 0b111];
+		cpu.timers.timer[2].reg_write(address & 0b111, data & TIMER_MASK[address & 0b111]);
 		break ;
 	}
 }

--- a/core/wasm/main.cc
+++ b/core/wasm/main.cc
@@ -227,8 +227,8 @@ static const StructDecl BlitterOverlay = {
 static const StructDecl TimerInstance = {
 	sizeof(Timers::Timer),
 	(const FieldDecl[]) {
-		FIELD("hi_flags", Timers::Timer, bytes[0], TYPE_BOOL),
-		FIELD("lo_flags", Timers::Timer, bytes[1], TYPE_BOOL),
+		FIELD("lo_flags", Timers::Timer, lo_flags, TYPE_UINT8),
+		FIELD("hi_flags", Timers::Timer, hi_flags, TYPE_UINT8),
 		FIELD("preset", Timers::Timer, preset, TYPE_UINT16),
 		FIELD("compare", Timers::Timer, compare, TYPE_UINT16),
 		FIELD("count", Timers::Timer, count, TYPE_UINT16),
@@ -246,7 +246,7 @@ static const StructDecl TimerInstance = {
 static const StructDecl TimersState = {
 	sizeof(Timers::State),
 	(const FieldDecl[]) {
-		STRUCT("timer", Timers::State, timer[3], TimerInstance, SIZE(3)),
+		STRUCT("timer", Timers::State, timer, TimerInstance, SIZE(3)),
 		FIELD("osc1_enable", Timers::State, osc1_enable, TYPE_BOOL),
 		FIELD("osc3_enable", Timers::State, osc3_enable, TYPE_BOOL),
 		FIELD("osc1_prescale", Timers::State, osc1_prescale, TYPE_UINT32),

--- a/src/system/machine-state.ts
+++ b/src/system/machine-state.ts
@@ -149,8 +149,9 @@ export interface BlitterOverlay {
 }
 
 export interface TimerInstance {
-    hi_flags: WasmBool;
-    lo_flags: WasmBool;
+    /** raw flag bytes: bits 0-3 input/preset/running/output; bit 7 of lo_flags is mode16 */
+    lo_flags: number;
+    hi_flags: number;
     preset: number;
     compare: number;
     count: number;


### PR DESCRIPTION
## Summary

Core-portability phase 2 (continuing PR #39's pattern): the Control, Input, Timers, and Blitter register files drop their byte-array ↔ bitfield unions — implementation-defined layout — for plain stored bytes + mask constants + inline accessors:

- **Control::State** — keeps `data[3]` as storage; `lcd_enabled()` / `cart_enabled()` read bits of `data[0]`
- **Input::State** — keeps `bytes[6]`; the 10-bit `interrupt_direction` / `input_state` packed fields become little-endian accessors; `__attribute__((packed))` gone
- **Timers::Timer** — `lo_flags`/`hi_flags` bytes + plain uint16 `preset`/`compare`/`count`; the guest's 8-byte register window goes through `reg_read()`/`reg_write()`; per-half byte lanes are explicit shifts/masks; `__attribute__((packed))` gone
- **Blitter::State** — raw `enables`/`rate_control` bytes + uint32 `map_base`/`sprite_base` with 3-byte shift/mask register helpers

### Reflection fixes that fell out

Two known bugs in the Timer reflection table (flagged back in PR #37) are fixed now that the fields are real members:
- `STRUCT("timer", ..., timer[3], ...)` took `offsetof` one past the array — UI reads of `state.timers.timer[*]` saw wrong memory
- `lo_flags`/`hi_flags` were **swapped** (`bytes[0]` is the lo half) and typed `TYPE_BOOL` despite holding multi-bit flag bytes — now `TYPE_UINT8` over the named members, `machine-state.ts` mirrored

## Verification

- **Bit-identical**: 3 ROMs (6shades, Pichu Bros, Pokemon Party) × 30 virtual seconds, FNV-hashed semantic state (registers + RAM + LCD gddram) per second — matches the pre-change baselines exactly, under **both clang and g++**
- **Register window round-trip** (browser, via reflection): wrote `preset=0xBEEF`/`compare=0x1234` through 0x2032-35 — reads back exactly through both `state.timers.timer[0].*` and guest reads; mode16 `setup_timer` semantics preserved (`hi_flags 0x0F→0x08`: input/preset/running cleared, output kept); `timer[2]`'s window lands in `timer[2]` (offset bug really fixed)
- WASM core builds clean; `npm run check` clean; app boots and all panels render with sane reflected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)