### PR TITLE
Make the blitter's guest-memory overlays endian-generic

### DIFF
--- a/core/include/blitter.h
+++ b/core/include/blitter.h
@@ -23,23 +23,43 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 namespace Machine { struct State; };
 
 namespace Blitter {
-	union Sprite {
+	// Sprite flag bits (byte 3 of an OAM entry)
+	const uint8_t SPRITE_X_FLIP = 0x01;
+	const uint8_t SPRITE_Y_FLIP = 0x02;
+	const uint8_t SPRITE_INVERT = 0x04;
+	const uint8_t SPRITE_ENABLE = 0x08;
+
+	// A view over a 4-byte guest OAM entry: x, y (7 bits each), tile, flags
+	struct Sprite {
 		uint8_t bytes[4];
-		struct {
-			unsigned x:7;
-			unsigned:1;
 
-			unsigned y:7;
-			unsigned:1;
+		int x() const {
+			return bytes[0] & 0x7F;
+		}
 
-			unsigned tile:8;
+		int y() const {
+			return bytes[1] & 0x7F;
+		}
 
-			unsigned x_flip: 1;
-			unsigned y_flip: 1;
-			unsigned invert: 1;
-			unsigned enable: 1;
-			unsigned:4;
-		};
+		int tile() const {
+			return bytes[2];
+		}
+
+		bool x_flip() const {
+			return (bytes[3] & SPRITE_X_FLIP) != 0;
+		}
+
+		bool y_flip() const {
+			return (bytes[3] & SPRITE_Y_FLIP) != 0;
+		}
+
+		bool invert() const {
+			return (bytes[3] & SPRITE_INVERT) != 0;
+		}
+
+		bool enable() const {
+			return (bytes[3] & SPRITE_ENABLE) != 0;
+		}
 	};
 
 	struct Overlay {

--- a/core/src/blitter.cc
+++ b/core/src/blitter.cc
@@ -22,8 +22,9 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 static const int SCREEN_WIDTH = 96;
 static const int SCREEN_HEIGHT = 64;
 
-union FrameBuffer {
-	uint8_t  bytes[SCREEN_WIDTH][8];
+// Working render target: one 64-pixel column per screen X, with guest
+// framebuffer byte y occupying bits 8y..8y+7 (LSB = topmost pixel)
+struct FrameBuffer {
 	uint64_t column[SCREEN_WIDTH];
 };
 
@@ -125,23 +126,27 @@ void Blitter::clock(Machine::State& cpu) {
 		}
 	} else {
 		for (int x = 0; x < SCREEN_WIDTH; x++) {
+			uint64_t column = 0;
+
 			for (int y = 0; y < 8; y++) {
-				target.bytes[x][y] = cpu.overlay.framebuffer[y][x];
+				column |= (uint64_t)cpu.overlay.framebuffer[y][x] << (8 * y);
 			}
+
+			target.column[x] = column;
 		}
 	}
 
 	if (cpu.blitter.enable_sprites()) {
 		for (int i = 23; i >= 0; i--) {
 			Sprite& sprite = cpu.overlay.oam[i];
-		
-			if (!sprite.enable) continue ;
 
-			auto address = cpu.blitter.sprite_base + sprite.tile * (8 * 8);
-			int dx = sprite.x - 16;
-			int dy = sprite.y - 16;
+			if (!sprite.enable()) continue ;
 
-			int invert = sprite.x_flip ? 0b0100111 : 0;
+			auto address = cpu.blitter.sprite_base + sprite.tile() * (8 * 8);
+			int dx = sprite.x() - 16;
+			int dy = sprite.y() - 16;
+
+			int invert = sprite.x_flip() ? 0b0100111 : 0;
 
 			if (dy <= -16 || dy >= SCREEN_HEIGHT) continue ;
 
@@ -162,12 +167,12 @@ void Blitter::clock(Machine::State& cpu) {
 					trace_access(cpu, (address^invert)+16, TRACE_SPRITE_DATA);
 					trace_access(cpu, (address^invert)+24, TRACE_SPRITE_DATA);
 
-					if (sprite.y_flip) {
+					if (sprite.y_flip()) {
 						mask = rev(mask);
 						draw = rev(draw);
 					}
 
-					if (sprite.invert) {
+					if (sprite.invert()) {
 						draw = ~draw;
 					}
 
@@ -184,7 +189,7 @@ void Blitter::clock(Machine::State& cpu) {
 	// Copy back to ram
 	for (int x = 0; x < SCREEN_WIDTH; x++) {
 		for (int y = 0; y < 8; y++) {
-			cpu.overlay.framebuffer[y][x] = target.bytes[x][y];
+			cpu.overlay.framebuffer[y][x] = (uint8_t)(target.column[x] >> (8 * y));
 		}
 	}
 


### PR DESCRIPTION
## Summary

Core-portability phase 3 of 4 — the two guest-memory overlays in the blitter:

- **`Blitter::Sprite`** — the bitfield union over 4-byte guest OAM entries becomes a plain `bytes[4]` struct with inline accessors (`x()`, `y()`, `tile()`, `enable()`, `x_flip()`, `y_flip()`, `invert()`); layout no longer depends on bitfield allocation order. The wasm reflection table already read `bytes[0..3]`, so it's untouched and `machine-state.ts` is unchanged.
- **`FrameBuffer`** — the `bytes[96][8]` ↔ `uint64_t column[96]` union baked LE byte order into the column trick. It now stores columns only; the framebuffer↔column conversions use explicit shifts (`byte y` ↔ `bits 8y..8y+7`), keeping the fast 64-bit blit path.

The `ram`/`overlay` union in `machine.h` stays: it's the intentional guest-RAM aliasing mechanism, and with `Sprite` now plain bytes the whole `Overlay` is deterministic `uint8_t` arrays — the final-sweep PR will add `static_assert`s on its size/offsets.

## Verification

- **Bit-identical**: same harness as PR #48 — 3 ROMs × 30 virtual seconds of FNV-hashed semantic state (registers + RAM + LCD gddram), exact match against pre-change baselines under **both clang and g++** (the ROMs render sprite-heavy scenes, exercising the flip/invert paths)
- WASM core builds clean; `npm run check` clean

Remaining: phase 4 sweep (`static_assert` struct sizes, any remaining packed attributes, libretro `link.T`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)