### PR TITLE
Pin guest-aliased layouts and add the missing libretro link script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,12 +56,6 @@ The libretro front-end (`core/libretro/libretro.cc`) wraps the same core; it doe
 
 Agreed ongoing work, one branch/PR per item (see Workflow). Update this list as items land.
 
-**Core portability** — make the core compiler- and platform-generic: no endianness assumptions, no packed bitfields or type-punning unions, just plain fields and explicit bit math. Done: CPU register state (PR #39). Remaining, in order:
-
-1. Peripheral register files — `control.h`, `input.h`, `timers.h`, `blitter.h` `State`: byte-array ↔ bitfield unions become stored raw bytes with bit-math helpers (timers is the fiddliest: nested 16-bit `preset`/`compare`/`count` unions drive the countdown math).
-2. Guest-memory overlays — `Blitter::Sprite` bitfields over OAM bytes and the `FrameBuffer` `bytes[96][8]` ↔ `uint64_t column[96]` punning in `blitter.cc` become explicit shifts/masks.
-3. Sweep — remove remaining `__attribute__((packed))`, `static_assert` struct sizes, reconcile the wasm reflection tables (and `machine-state.ts`); fix the `offsetof(Timers::State, timer[3])` reflection bug; the libretro link needs its missing `link.T` script.
-
-Verify every phase bit-identical: build the core natively, run ROMs headless, hash semantic state (register values + RAM + LCD gddram — never raw struct bytes) per virtual second, and diff against a pre-change baseline (see PR #39 for the recipe). Note that layout changes invalidate raw-`memcpy` libretro savestates; there is no savestate versioning.
+**Core portability** — COMPLETE: the core is compiler- and platform-generic — no endianness assumptions, no packed bitfields or type-punning unions, just plain fields and explicit bit math. CPU register state (PR #39), peripheral register files incl. the Timer reflection fixes (PR #48), guest-memory overlays (PR #49), layout `static_assert`s + libretro `link.T` (PR #50). When changing core state layout, verify bit-identical behavior: build the core natively, run ROMs headless, hash semantic state (register values + RAM + LCD gddram — never raw struct bytes) per virtual second, and diff against a pre-change baseline (see PR #39 for the recipe). Note that layout changes invalidate raw-`memcpy` libretro savestates; there is no savestate versioning.
 
 **UI modernization** — COMPLETE: Vite (PR #35), strict-TS system layer (PR #37), hooks/`useSyncExternalStore` refactor (PR #41), library swaps (`@tanstack/react-virtual` PR #42, native controls PR #43, dockview PR #44), AudioWorklet (PR #45), GitHub Actions CI (PR #47). CI runs a type check plus the full build (instruction table, WASM core, Vite) on every PR and push to main — see `.github/workflows/ci.yml`.

--- a/core/include/blitter.h
+++ b/core/include/blitter.h
@@ -19,6 +19,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 
 namespace Machine { struct State; };
 
@@ -69,6 +70,14 @@ namespace Blitter {
 		// a union arm are not portable C++)
 		uint8_t map[0x1000 - sizeof(uint8_t[8][96]) - sizeof(Sprite[24])];
 	};
+
+	// Overlay is a view over the guest's 4KB RAM window (it shares a
+	// union with Machine::State::ram); pin the layout so a compiler
+	// that pads these structs fails loudly instead of corrupting state
+	static_assert(sizeof(Sprite) == 4, "OAM entries are 4 guest bytes");
+	static_assert(sizeof(Overlay) == 0x1000, "Overlay must span the RAM window exactly");
+	static_assert(offsetof(Overlay, oam) == 768, "OAM must directly follow the framebuffer");
+	static_assert(offsetof(Overlay, map) == 864, "map data must directly follow OAM");
 
 	// enables bits (0x2080)
 	const uint8_t ENABLES_INVERT_MAP     = 0x01;

--- a/core/include/machine.h
+++ b/core/include/machine.h
@@ -141,6 +141,9 @@ namespace Machine {
 		int osc1_overflow;
 		Status status;
 
+		// The blitter's overlay is a structured view over guest RAM;
+		// both arms are plain byte arrays of identical size (asserted
+		// in blitter.h), so the aliasing is layout-deterministic
 		union {
 			uint8_t ram[0x1000];
 		 	Blitter::Overlay overlay;

--- a/core/libretro/link.T
+++ b/core/libretro/link.T
@@ -1,0 +1,4 @@
+{
+   global: retro_*;
+   local: *;
+};


### PR DESCRIPTION
## Summary

Final core-portability phase — the sweep. The packed-attribute scan came back **already clean** (PRs #39/#48/#49 removed them all), so what remained:

- **`static_assert`s** pin the one remaining layout contract: `Sprite` is 4 guest bytes, `Overlay` spans the 4KB RAM window exactly (OAM at 768, map at 864). A compiler that pads these structs now fails to build instead of silently corrupting guest state. The `ram`/`overlay` union stays as the intentional aliasing mechanism — it's deterministic byte arrays on both arms now.
- **`core/libretro/link.T`** — referenced by every shared-library target in the libretro Makefile, never committed. The standard libretro version script (`global: retro_*; local: *;`) makes the core **link on Linux for the first time**.

This completes the core-portability roadmap: no endianness assumptions, no packed bitfields, no type-punning unions anywhere in the core.

## Verification

- Bit-identical against the baselines: 3 ROMs × 30 virtual seconds of hashed semantic state, clang **and** g++
- `minimon_libretro.so` builds and links on Linux; `nm -D` shows exactly the `retro_*` ABI exported, zero stray symbols
- The `static_assert`s hold under clang, g++, **and** the wasm32 WASI build; `npm run check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)