### PR TITLE
Fix a batch of small correctness issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
 
       - run: npm ci
 
-      # npm run build chains its steps with `;`, which would mask a core
-      # build failure; run them individually so each failure fails the job
+      # Equivalent to npm run build, but as separate steps so a failure
+      # is attributed to the right stage in the job UI
       - name: Generate instruction table
         run: npm run table
 

--- a/core/libretro/libretro.cc
+++ b/core/libretro/libretro.cc
@@ -110,7 +110,7 @@ bool retro_unserialize(const void *data, size_t size) {
     if (size != sizeof(machine_state)) return false;
 
     memcpy(&machine_state, data, size);
-    return false;
+    return true;
 }
 
 // End of retrolib

--- a/core/src/rtc.cc
+++ b/core/src/rtc.cc
@@ -30,9 +30,9 @@ void RTC::clock(Machine::State& cpu, int osc1) {
 	if (cpu.rtc.running) {
 		cpu.rtc.prescale += osc1;
 
-		while (cpu.rtc.prescale >= 0x8000)	 {
+		while (cpu.rtc.prescale >= 0x8000) {
 			cpu.rtc.value ++;
-			cpu.rtc.prescale -= cpu.rtc.prescale;
+			cpu.rtc.prescale -= 0x8000;
 		}
 	}
 }

--- a/core/test/baseline-bios.txt
+++ b/core/test/baseline-bios.txt
@@ -1,30 +1,30 @@
-  1 05d53dcee81ed965 pc=01:08bb status=0 ctrl=7f
-  2 7045dea79854f264 pc=01:0d5b status=0 ctrl=7f
-  3 a50e98174b0cd44a pc=01:0d5e status=0 ctrl=7f
-  4 ab2c3a6186128b3b pc=01:0d5e status=0 ctrl=7f
-  5 e9a1fd1bfd53f204 pc=01:0d5e status=0 ctrl=7f
-  6 4bdc015c3d05c211 pc=01:0d5b status=0 ctrl=7f
-  7 6c95f7b5e995003b pc=01:0d5e status=0 ctrl=7f
-  8 d2d4290ffa085ea8 pc=01:0d5b status=0 ctrl=7f
-  9 0b1b2b40a207377a pc=01:0d5e status=0 ctrl=7f
- 10 0b0e52566fc0b1d3 pc=01:0d5e status=0 ctrl=7f
- 11 e69510ec860d7a62 pc=01:0d5b status=0 ctrl=7f
- 12 a449747c4eba7372 pc=01:0d5e status=0 ctrl=7f
- 13 20b82137f0932e43 pc=01:0d5b status=0 ctrl=7f
- 14 bf2e63ccee8cd6ea pc=01:0d5b status=0 ctrl=7f
- 15 2129d70098773d04 pc=01:0d5e status=0 ctrl=7f
- 16 d1962a6e5ccfb602 pc=01:0d5e status=0 ctrl=7f
- 17 8305010739d17028 pc=01:0d5b status=0 ctrl=7f
- 18 29e25bb0a7fc9e8b pc=01:0d5e status=0 ctrl=7f
- 19 ded4fc2b7c2c6b95 pc=01:0d5b status=0 ctrl=7f
- 20 eec9b7451b5f5e4c pc=01:0d5b status=0 ctrl=7f
- 21 f6b2c62debd8c5c6 pc=01:0d5e status=0 ctrl=7f
- 22 f85efd21f8688f98 pc=01:0d5e status=0 ctrl=7f
- 23 88ab7a41493e494b pc=01:0d5e status=0 ctrl=7f
- 24 c512f7237c6ded45 pc=01:0d5e status=0 ctrl=7f
- 25 25de1c84d9cb0697 pc=01:0d5b status=0 ctrl=7f
- 26 0989fac9363d66ae pc=01:0d5b status=0 ctrl=7f
- 27 73fcbe31c4d8a7b3 pc=01:0d5e status=0 ctrl=7f
- 28 13258ed66f28c7a3 pc=01:0d5b status=0 ctrl=7f
- 29 1aea94911a380e1e pc=01:0d5e status=0 ctrl=7f
- 30 5ddb491a89431a67 pc=01:0d5e status=0 ctrl=7f
+  1 05d53dcee81ed965 pc=01:08bb status=0 ctrl=7f rtc=000000+2000
+  2 7045dea79854f264 pc=01:0d5b status=0 ctrl=7f rtc=000000+4000
+  3 a50e98174b0cd44a pc=01:0d5e status=0 ctrl=7f rtc=000000+6000
+  4 ab2c3a6186128b3b pc=01:0d5e status=0 ctrl=7f rtc=000001+0000
+  5 e9a1fd1bfd53f204 pc=01:0d5e status=0 ctrl=7f rtc=000001+2000
+  6 4bdc015c3d05c211 pc=01:0d5b status=0 ctrl=7f rtc=000001+4000
+  7 6c95f7b5e995003b pc=01:0d5e status=0 ctrl=7f rtc=000001+6000
+  8 d2d4290ffa085ea8 pc=01:0d5b status=0 ctrl=7f rtc=000002+0000
+  9 0b1b2b40a207377a pc=01:0d5e status=0 ctrl=7f rtc=000002+2000
+ 10 0b0e52566fc0b1d3 pc=01:0d5e status=0 ctrl=7f rtc=000002+4000
+ 11 e69510ec860d7a62 pc=01:0d5b status=0 ctrl=7f rtc=000002+6000
+ 12 a449747c4eba7372 pc=01:0d5e status=0 ctrl=7f rtc=000003+0000
+ 13 20b82137f0932e43 pc=01:0d5b status=0 ctrl=7f rtc=000003+2000
+ 14 bf2e63ccee8cd6ea pc=01:0d5b status=0 ctrl=7f rtc=000003+4000
+ 15 2129d70098773d04 pc=01:0d5e status=0 ctrl=7f rtc=000003+6000
+ 16 d1962a6e5ccfb602 pc=01:0d5e status=0 ctrl=7f rtc=000004+0000
+ 17 8305010739d17028 pc=01:0d5b status=0 ctrl=7f rtc=000004+2000
+ 18 29e25bb0a7fc9e8b pc=01:0d5e status=0 ctrl=7f rtc=000004+4000
+ 19 ded4fc2b7c2c6b95 pc=01:0d5b status=0 ctrl=7f rtc=000004+6000
+ 20 eec9b7451b5f5e4c pc=01:0d5b status=0 ctrl=7f rtc=000005+0000
+ 21 f6b2c62debd8c5c6 pc=01:0d5e status=0 ctrl=7f rtc=000005+2000
+ 22 f85efd21f8688f98 pc=01:0d5e status=0 ctrl=7f rtc=000005+4000
+ 23 88ab7a41493e494b pc=01:0d5e status=0 ctrl=7f rtc=000005+6000
+ 24 c512f7237c6ded45 pc=01:0d5e status=0 ctrl=7f rtc=000006+0000
+ 25 25de1c84d9cb0697 pc=01:0d5b status=0 ctrl=7f rtc=000006+2000
+ 26 0989fac9363d66ae pc=01:0d5b status=0 ctrl=7f rtc=000006+4000
+ 27 73fcbe31c4d8a7b3 pc=01:0d5e status=0 ctrl=7f rtc=000006+6000
+ 28 13258ed66f28c7a3 pc=01:0d5b status=0 ctrl=7f rtc=000007+0000
+ 29 1aea94911a380e1e pc=01:0d5e status=0 ctrl=7f rtc=000007+2000
+ 30 5ddb491a89431a67 pc=01:0d5e status=0 ctrl=7f rtc=000007+4000

--- a/core/test/baseline-exercise.txt
+++ b/core/test/baseline-exercise.txt
@@ -1,30 +1,30 @@
-  1 48d0c551a2c1c4f2 pc=01:0d5e status=0 ctrl=7f
-  2 6945c239e639f2f4 pc=01:0d5b status=0 ctrl=7f
-  3 c0c942444ac88b66 pc=01:0d5b status=0 ctrl=7f
-  4 b5a691312af211dd pc=01:0d5e status=0 ctrl=7f
-  5 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
-  6 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
-  7 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
-  8 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
-  9 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 10 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 11 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 12 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 13 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 14 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 15 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 16 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 17 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 18 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 19 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 20 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 21 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 22 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 23 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 24 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 25 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 26 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 27 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 28 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 29 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
- 30 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f
+  1 48d0c551a2c1c4f2 pc=01:0d5e status=0 ctrl=7f rtc=000000+4000
+  2 6945c239e639f2f4 pc=01:0d5b status=0 ctrl=7f rtc=000000+6000
+  3 c0c942444ac88b66 pc=01:0d5b status=0 ctrl=7f rtc=000001+0000
+  4 b5a691312af211dd pc=01:0d5e status=0 ctrl=7f rtc=000001+2000
+  5 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000001+4000
+  6 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000001+6000
+  7 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000002+0000
+  8 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000002+2000
+  9 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000002+4000
+ 10 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000002+6000
+ 11 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000003+0000
+ 12 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000003+2000
+ 13 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000003+4000
+ 14 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000003+6000
+ 15 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000004+0000
+ 16 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000004+2000
+ 17 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000004+4000
+ 18 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000004+6000
+ 19 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000005+0000
+ 20 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000005+2000
+ 21 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000005+4000
+ 22 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000005+6000
+ 23 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000006+0000
+ 24 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000006+2000
+ 25 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000006+4000
+ 26 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000006+6000
+ 27 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000007+0000
+ 28 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000007+2000
+ 29 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000007+4000
+ 30 c1d49c8bab4cb69b pc=01:07e6 status=1 ctrl=7f rtc=000007+6000

--- a/core/test/harness.cc
+++ b/core/test/harness.cc
@@ -98,6 +98,9 @@ static void exercise(Machine::State& m) {
 
 	// Audio: enabled, mid volume
 	cpu_write(m, 0b000, 0x2070); cpu_write(m, 0b010, 0x2071);
+
+	// RTC: running (value ticks once per 0x8000 osc1 cycles)
+	cpu_write(m, 0b01, 0x2008);
 }
 
 int main(int argc, char** argv) {
@@ -154,9 +157,10 @@ int main(int argc, char** argv) {
 		}
 
 		cpu_advance(machine, CPU_SPEED);
-		printf("%3d %016llx pc=%02x:%04x status=%d ctrl=%02x\n", s,
+		printf("%3d %016llx pc=%02x:%04x status=%d ctrl=%02x rtc=%06x+%04x\n", s,
 			(unsigned long long)hash_state(machine),
-			machine.reg.cb, machine.reg.pc, machine.status, machine.ctrl.data[0]);
+			machine.reg.cb, machine.reg.pc, machine.status, machine.ctrl.data[0],
+			machine.rtc.value & 0xFFFFFF, machine.rtc.prescale & 0xFFFF);
 	}
 
 	return 0;

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "core": "cd core; make wasm",
     "retroarch": "cd core/libretro; make test",
     "table": "python3 ./tools/convert.py > ./src/system/table.ts.tmp && mv ./src/system/table.ts.tmp ./src/system/table.ts",
-    "check": "npm run table; tsc --noEmit",
-    "start": "npm run table; vite",
-    "build": "npm run table; npm run core; vite build",
+    "check": "npm run table && tsc --noEmit",
+    "start": "npm run table && vite",
+    "build": "npm run table && npm run core && vite build",
     "preview": "vite preview",
-    "deploy": "npm run build; scp -r dist/* node@scyl.us:~/minimon/"
+    "deploy": "npm run build && scp -r dist/* node@scyl.us:~/minimon/"
   },
   "keywords": [],
   "author": "Bryon Vandiver",

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -63,7 +63,7 @@ interface CoreExports {
 
 export class Minimon {
 	state!: MachineState;
-	breakpoints: number[] = [];
+	breakpoints = new Set<number>();
 
 	private _listeners = new Set<() => void>();
 	private _version = 0;
@@ -200,11 +200,11 @@ export class Minimon {
 
 			time = now;
 
-			if (this.breakpoints.length) {
+			if (this.breakpoints.size) {
 				this.state.clocks += delta;	// advance our clock
 
 				while (this.state.clocks > 0) {
-					if (this.breakpoints.indexOf(this.translate(this.state.cpu.pc)) >= 0) {
+					if (this.breakpoints.has(this.translate(this.state.cpu.pc))) {
 						this.running = false;
 						break;
 					}

--- a/src/ui/disassemble/index.tsx
+++ b/src/ui/disassemble/index.tsx
@@ -60,10 +60,10 @@ export default function Disassembly({ follow_pc = true }: DisassemblyProps) {
 	});
 
 	function onClick(target: number) {
-		if (system.breakpoints.indexOf(target) >= 0) {
-			system.breakpoints = system.breakpoints.filter((v) => v != target);
+		if (system.breakpoints.has(target)) {
+			system.breakpoints.delete(target);
 		} else {
-			system.breakpoints.push(target);
+			system.breakpoints.add(target);
 		}
 
 		system.update();
@@ -84,7 +84,7 @@ export default function Disassembly({ follow_pc = true }: DisassemblyProps) {
 						<tr onClick={() => onClick(line.address)} key={line.address} className={(target == line.address) ? classes['active'] : ''}>
 							<td className={classes["address"]}>{toHex(line.address, 6)}</td>
 							<td>{line.data.map((v, i) => <span className={classes['byte-cell']} key={i}>{toHex(v, 2)}</span>)}</td>
-							<td className={system.breakpoints.indexOf(line.address) >= 0 ? classes['breakpoint'] : ''}>{line.op}</td>
+							<td className={system.breakpoints.has(line.address) ? classes['breakpoint'] : ''}>{line.op}</td>
 							<td>{line.args.map((s, i) => <span key={i}>{s}</span>)}</td>
 						</tr>)
 					}


### PR DESCRIPTION
## Summary

Four small, independent correctness fixes (stacked on #51 — retarget to main after it merges):

1. **RTC prescaler** (`rtc.cc`): `prescale -= prescale` zeroed the counter instead of subtracting the `0x8000` overflow threshold. **Honest severity:** latent, not symptomatic — `osc1` reaches `RTC::clock` one tick at a time, so the remainder at crossing is always zero and both forms coincide today. Verified by A/B: zero divergence on baselines *and* on 3 commercial ROMs × 30 s. It would silently lose time the moment osc1 delivery was ever batched. The harness exercise now **starts the RTC** and the log line prints `rtc=value+prescale`, so the subsystem is regression-covered going forward (baselines regenerated for the new column).
2. **libretro savestates** (`libretro.cc`): `retro_unserialize()` copied the state then returned `false` — every savestate load reported failure to the frontend. Now returns `true`.
3. **Breakpoints** are a `Set<number>` instead of an array — the running loop did an `indexOf` per executed instruction.
4. **npm scripts** chain with `&&` instead of `;` — a failed core build no longer lets `vite build` "succeed" with a stale wasm. (CI's stale comment about this updated too.)

## Verification

- RTC A/B (old vs fixed code): byte-identical exercise baselines and ROM runs — confirming both the fix's safety and its latent-only severity
- Breakpoints driven in the browser: set/set/clear via disassembly clicks, counts correct; running with a breakpoint on the BIOS idle loop halts immediately
- libretro `.so` builds; `npm run check`, wasm core build, and `make -C core/test check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)