### PR TITLE
Add the debugger document model with per-cartridge persistence

### DIFF
--- a/core/include/machine.h
+++ b/core/include/machine.h
@@ -155,6 +155,7 @@ namespace Machine {
 
 // Library functions
 extern "C" Machine::State* const get_machine();
+extern "C" const uint8_t* get_bios();
 
 extern "C" uint8_t cpu_read(Machine::State& cpu, uint32_t address);
 extern "C" void cpu_write(Machine::State& cpu, uint8_t data, uint32_t address);

--- a/core/src/machine.cc
+++ b/core/src/machine.cc
@@ -29,6 +29,13 @@ extern "C" const char* get_version() {
 	return "0.1.0";
 }
 
+// Read-only view of the embedded BIOS for the debugger: rendering must
+// not go through cpu_read, which captures the bus (and so perturbs
+// open-bus behavior)
+extern "C" const uint8_t* get_bios() {
+	return bios;
+}
+
 extern "C" void cpu_reset(Machine::State& cpu) {
 	cpu.reg.pc = cpu_read16(cpu, 0x0000);
 	cpu.reg.sc = 0xC0;

--- a/core/wasm/Makefile
+++ b/core/wasm/Makefile
@@ -25,7 +25,8 @@ EXPORTS = \
 	--export cpu_write \
 	--export get_description \
 	--export get_bios_trace \
-	--export get_cartridge_trace
+	--export get_cartridge_trace \
+	--export get_bios
 
 # The tracing core is the only build: classification maps live in wasm
 # memory (see main.cc) so the per-access trace hook never crosses into JS

--- a/src/system/debugger-document.ts
+++ b/src/system/debugger-document.ts
@@ -1,0 +1,191 @@
+/*
+ISC License
+
+Copyright (c) 2019, Bryon Vandiver
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+/*
+ * The debugger's document model: turns the CPU's 64K view — BIOS, RAM,
+ * hardware registers, bank 0 of the cartridge in the lower half, a
+ * selected bank in the upper half — into a list of renderable lines
+ * using the core's classification maps.
+ *
+ * A byte the CPU has executed is code (one line per instruction,
+ * disassembled); a byte it has only read/written is data; a byte it has
+ * never touched is unknown. Data and unknown render as 16-byte hex rows
+ * aligned to 16-byte boundaries (rows break early where classification
+ * changes). RAM and hardware registers are always data.
+ *
+ * All reads here are side-effect-free: rendering must never go through
+ * cpu_read, which captures the bus.
+ */
+
+import { Disassembler } from "./disassemble";
+import { TRACING_FLAGS, type Minimon } from "./index";
+
+export type LineKind = 'code' | 'data' | 'unknown';
+
+export interface DocumentLine {
+	kind: LineKind;
+	/** CPU-visible address (0x0000-0xFFFF) */
+	address: number;
+	/** physical address after bank mapping */
+	physical: number;
+	length: number;
+
+	/** disassembly, code lines only */
+	op?: string;
+	args?: string[];
+}
+
+export interface DebuggerDocument {
+	bank: number;
+	lines: DocumentLine[];
+	/** index of the line containing a CPU address */
+	lineAt(address: number): number;
+	/** side-effect-free byte read for rendering hex rows */
+	byteAt(address: number): number | null;
+}
+
+const BANK_WINDOW = 0x8000;
+const HEX_ROW = 16;
+
+// Classification flags that mean "the CPU executed this byte"
+const CODE_FLAGS = TRACING_FLAGS.INSTRUCTION;
+
+function physical(address: number, bank: number): number {
+	return (address & 0x8000) ? ((address & 0x7FFF) | (bank * BANK_WINDOW)) : address;
+}
+
+export function buildDocument(system: Minimon, bank: number): DebuggerDocument {
+	const { biosTrace, cartridgeTrace, bios, state } = system;
+
+	// null = unreadable for rendering (hardware registers are computed
+	// on read; reading them perturbs the machine)
+	function byteAt(address: number): number | null {
+		const p = physical(address, bank);
+
+		if (p < 0x1000) return bios[p];
+		if (p < 0x2000) return state.ram[p - 0x1000];
+		if (p < 0x2100) return null;
+		return state.cartridge[p & 0x1FFFFF];
+	}
+
+	function classify(address: number): LineKind {
+		const p = physical(address, bank);
+
+		if (p < 0x1000) {
+			const flags = biosTrace[p];
+			if (flags & CODE_FLAGS) return 'code';
+			return flags ? 'data' : 'unknown';
+		}
+
+		// RAM and hardware registers are always data
+		if (p < 0x2100) return 'data';
+
+		const flags = cartridgeTrace[p & 0x1FFFFF];
+		if (flags & CODE_FLAGS) return 'code';
+		return flags ? 'data' : 'unknown';
+	}
+
+	// Code lines decode through the shared disassembler with an
+	// explicit bank mapping and side-effect-free reads
+	const disasm = new Disassembler({
+		translate: (address) => physical(address, bank),
+		read: (p) => {
+			if (p < 0x1000) return bios[p];
+			if (p < 0x2000) return state.ram[p - 0x1000];
+			if (p < 0x2100) return 0;
+			return state.cartridge[p & 0x1FFFFF];
+		}
+	});
+
+	const lines: DocumentLine[] = [];
+	// Line index of each 256-byte page start, for O(1)-ish address lookup
+	const pageIndex = new Int32Array(0x100).fill(-1);
+
+	let address = 0;
+
+	while (address <= 0xFFFF) {
+		const page = address >> 8;
+		if (pageIndex[page] < 0) pageIndex[page] = lines.length;
+
+		const kind = classify(address);
+
+		if (kind === 'code') {
+			const line = disasm.process(address, 1)[0];
+
+			if (line) {
+				lines.push({
+					kind, address,
+					physical: physical(address, bank),
+					length: line.data.length,
+					op: line.op,
+					args: line.args,
+				});
+				address += line.data.length;
+				continue;
+			}
+			// Undecodable despite the flag (e.g. table gap): fall
+			// through and emit it as a data row instead
+		}
+
+		// Hex row: up to the next 16-byte boundary, breaking early if
+		// the classification changes
+		const rowEnd = Math.min((address & ~(HEX_ROW - 1)) + HEX_ROW, 0x10000);
+		let end = address + 1;
+		while (end < rowEnd && classify(end) === kind) end++;
+
+		lines.push({
+			kind: kind === 'code' ? 'data' : kind,
+			address,
+			physical: physical(address, bank),
+			length: end - address,
+		});
+		address = end;
+	}
+
+	function lineAt(target: number): number {
+		let index = pageIndex[(target >> 8) & 0xFF];
+		if (index < 0) index = 0;
+
+		while (index < lines.length - 1 && lines[index].address + lines[index].length <= target) index++;
+		return index;
+	}
+
+	return { bank, lines, lineAt, byteAt };
+}
+
+/*
+ * Memoizes a document per (bank, state version): the trace maps mutate
+ * continuously while the machine runs, so consumers pass the system's
+ * version counter as the invalidation key (one rebuild per UI frame at
+ * worst).
+ */
+export class DocumentCache {
+	private _document: DebuggerDocument | null = null;
+	private _bank = -1;
+	private _version = -1;
+
+	get(system: Minimon, bank: number, version: number): DebuggerDocument {
+		if (!this._document || bank !== this._bank || version !== this._version) {
+			this._document = buildDocument(system, bank);
+			this._bank = bank;
+			this._version = version;
+		}
+
+		return this._document;
+	}
+}

--- a/src/system/disassemble.ts
+++ b/src/system/disassemble.ts
@@ -18,7 +18,13 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import * as Table from "./table.ts";
 
-import type { Minimon } from "./index";
+// Anything that can serve byte fetches: Minimon satisfies this (reading
+// through the live CPU bus), and the debugger document model supplies a
+// side-effect-free reader with an explicit bank mapping instead
+export interface MemoryAccess {
+	read(address: number): number;
+	translate(address: number): number;
+}
 
 interface Instruction {
 	op: string;
@@ -43,11 +49,11 @@ function toHex(v: number, c: number): string {
 }
 
 export class Disassembler {
-	private _system: Minimon;
+	private _system: MemoryAccess;
 	private _address = 0;
 	private _data: number[] = [];
 
-	constructor(system: Minimon) {
+	constructor(system: MemoryAccess) {
 		this._system = system;
 	}
 

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -18,6 +18,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import struct from "./state";
 import Audio from "./audio";
+import { loadMap, saveMap, cartridgeKey, BIOS_KEY } from "./trace-store";
 
 import type { MachineState } from "./machine-state";
 
@@ -61,10 +62,13 @@ interface CoreExports {
 	cpu_write(machine: number, data: number, address: number): void;
 	get_bios_trace(): number;
 	get_cartridge_trace(): number;
+	get_bios(): number;
 }
 
 const BIOS_TRACE_SIZE = 0x1000;
 const CARTRIDGE_TRACE_SIZE = 0x200000;
+const BIOS_SIZE = 0x1000;
+const TRACE_SAVE_INTERVAL = 10000;
 
 export class Minimon {
 	state!: MachineState;
@@ -75,6 +79,12 @@ export class Minimon {
 	// is cleared whenever the cartridge changes
 	biosTrace!: Uint8Array;
 	cartridgeTrace!: Uint8Array;
+
+	// Read-only view of the embedded BIOS, for side-effect-free
+	// debugger rendering
+	bios!: Uint8Array;
+
+	private _cartKey: string | null = null;
 
 	private _listeners = new Set<() => void>();
 	private _version = 0;
@@ -97,6 +107,13 @@ export class Minimon {
 		window.addEventListener("beforeunload", () => {
 			this.preserve();
 		}, false);
+
+		// IndexedDB writes are async and can't ride beforeunload, so
+		// classification persists on an interval and when the tab hides
+		setInterval(() => this.preserveTrace(), TRACE_SAVE_INTERVAL);
+		document.addEventListener("visibilitychange", () => {
+			if (document.visibilityState === "hidden") this.preserveTrace();
+		});
 
 		document.body.addEventListener('keydown', (e) => {
 			this._inputState &= ~(KEYBOARD_CODES[e.keyCode] ?? 0);
@@ -158,10 +175,33 @@ export class Minimon {
 
 		this.biosTrace = new Uint8Array(this._exports.memory.buffer, this._exports.get_bios_trace(), BIOS_TRACE_SIZE);
 		this.cartridgeTrace = new Uint8Array(this._exports.memory.buffer, this._exports.get_cartridge_trace(), CARTRIDGE_TRACE_SIZE);
+		this.bios = new Uint8Array(this._exports.memory.buffer, this._exports.get_bios(), BIOS_SIZE);
+
+		// The BIOS classification is universal; pick up where any
+		// previous session left off
+		try {
+			const saved = await loadMap(BIOS_KEY);
+			if (saved && saved.length === this.biosTrace.length) {
+				this.biosTrace.set(saved);
+			}
+		} catch (e) {
+			console.warn("Could not restore BIOS classification", e);
+		}
 
 		this._exports.set_sample_rate(this._cpu_state, this._audio.sampleRate);
 		this.reset();
 		this.restore();
+	}
+
+	// Classification maps persist across sessions: the BIOS map always,
+	// the cartridge map keyed by ROM hash
+	preserveTrace(): void {
+		if (!this.biosTrace) return;
+
+		void saveMap(BIOS_KEY, this.biosTrace).catch(() => {});
+		if (this._cartKey) {
+			void saveMap(this._cartKey, this.cartridgeTrace).catch(() => {});
+		}
 	}
 
 	private _wasm_environment = {
@@ -273,8 +313,21 @@ export class Minimon {
 		const hasHeader = (bytes[0] != 0x50 || bytes[1] != 0x4D);
 		const offset = hasHeader ? 0 : 0x2100;
 
-		setTimeout(() => {
+		setTimeout(async () => {
 			for (let i = bytes.length - 1; i >= 0; i--) this.state.cartridge[(i + offset) & 0x1FFFFF] = bytes[i];
+
+			// Restore this cartridge's classification, if it has
+			// visited before
+			this._cartKey = cartridgeKey(this.state.cartridge);
+			try {
+				const saved = await loadMap(this._cartKey);
+				if (saved && saved.length === this.cartridgeTrace.length) {
+					this.cartridgeTrace.set(saved);
+				}
+			} catch (e) {
+				console.warn("Could not restore cartridge classification", e);
+			}
+
 			this._inputState &= ~INPUT_CART_N;
 			this._updateinput();
 		}, 100);
@@ -283,7 +336,13 @@ export class Minimon {
 	}
 
 	eject(): void {
-		// The classification belongs to the departing cartridge
+		// The classification belongs to the departing cartridge: save
+		// it under that cartridge's key, then clear. Snapshot before
+		// clearing — the save commits asynchronously.
+		if (this._cartKey) {
+			void saveMap(this._cartKey, this.cartridgeTrace.slice()).catch(() => {});
+			this._cartKey = null;
+		}
 		this.cartridgeTrace.fill(0);
 
 		this._inputState |= INPUT_CART_N;

--- a/src/system/trace-store.ts
+++ b/src/system/trace-store.ts
@@ -1,0 +1,85 @@
+/*
+ISC License
+
+Copyright (c) 2019, Bryon Vandiver
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+/*
+ * Persistence for the debugger's classification maps. The 2MB cartridge
+ * map exceeds what localStorage can hold, so both maps live in
+ * IndexedDB: the BIOS map under a fixed key (the BIOS never changes),
+ * cartridge maps keyed by a hash of the ROM contents.
+ */
+
+const DB_NAME = "minimon-trace";
+const STORE = "maps";
+
+export const BIOS_KEY = "bios";
+
+let database: Promise<IDBDatabase> | null = null;
+
+function open(): Promise<IDBDatabase> {
+	if (!database) {
+		database = new Promise((resolve, reject) => {
+			const request = indexedDB.open(DB_NAME, 1);
+
+			request.onupgradeneeded = () => {
+				request.result.createObjectStore(STORE);
+			};
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+	}
+
+	return database;
+}
+
+export async function loadMap(key: string): Promise<Uint8Array | null> {
+	const db = await open();
+
+	return new Promise((resolve, reject) => {
+		const request = db.transaction(STORE, "readonly").objectStore(STORE).get(key);
+
+		request.onsuccess = () => resolve(request.result instanceof Uint8Array ? request.result : null);
+		request.onerror = () => reject(request.error);
+	});
+}
+
+export async function saveMap(key: string, data: Uint8Array): Promise<void> {
+	const db = await open();
+
+	return new Promise((resolve, reject) => {
+		// Copy out of WASM memory: the live view's buffer can't be
+		// structured-cloned while it keeps mutating
+		const tx = db.transaction(STORE, "readwrite");
+		tx.objectStore(STORE).put(data.slice(), key);
+
+		tx.oncomplete = () => resolve();
+		tx.onerror = () => reject(tx.error);
+	});
+}
+
+// FNV-1a over the ROM contents; identifies a cartridge for map storage
+export function cartridgeKey(rom: Uint8Array): string {
+	let hi = 0x811c9dc5 | 0;
+	let lo = 0x01000193 | 0;
+
+	for (let i = 0; i < rom.length; i++) {
+		hi = ((hi ^ rom[i]) * 0x01000193) >>> 0;
+		lo = ((lo ^ rom[i] ^ (hi >>> 24)) * 0x01000193) >>> 0;
+	}
+
+	return `cart:${hi.toString(16).padStart(8, "0")}${lo.toString(16).padStart(8, "0")}`;
+}


### PR DESCRIPTION
## Summary

PR C of the debugger rewrite — the testable middle layer between the core's classification maps (#54) and the upcoming panel (PR D).

**Document model** (`src/system/debugger-document.ts`):
- Segments the CPU's 64K view (BIOS / RAM / registers / cart bank 0 low / selected bank high) into lines: one disassembled line per executed instruction, **16-byte-aligned hex rows** for data/unknown (breaking early at classification changes), RAM/registers always data
- Lines carry CPU + physical addresses; `lineAt()` resolves address→line via a per-page index; `byteAt()` provides render-safe byte reads
- `DocumentCache` memoizes per (bank, state version)

**Side-effect-free rendering, by construction:** `cpu_read` captures the bus (`bus_cap`) and hardware registers compute on read — the current disassembly panel actually perturbs the machine while rendering. The model reads only direct views: a new `get_bios` export, `state.ram`, `state.cartridge`; registers report as unreadable. `Disassembler` now takes a narrow `MemoryAccess` interface so the model can supply a bank-explicit reader (Minimon still satisfies it structurally for the legacy panel).

**Persistence** (`src/system/trace-store.ts`, IndexedDB — 2MB maps exceed localStorage):
- BIOS map under a fixed key, restored on `init()`
- Cartridge map keyed by FNV hash of ROM contents: restored on `load()`, **snapshotted synchronously then saved on `eject()`** (the async commit can't race the clear), flushed every 10s and on tab-hide

## Verification (browser, headless)

- Full 64K segmentation in **2.1 ms**; 4,588 lines covering exactly 65,536 bytes, contiguous, zero misaligned/oversized hex rows
- First code line = the reset vector: `0x009A: LD EP, #00h`
- `lineAt()` round-trips 64 random addresses; `byteAt` matches BIOS/RAM views, returns null for registers
- Bank windowing: `0x9000` → physical `0x1000` (bank 0) vs `0x9000` (bank 1); lower half identical across banks
- Cache: same reference for same (bank, version), rebuilds on version change
- **Persistence round-trip: 985 classified BIOS bytes restored after a full page reload with zero stepping**
- `npm run check`, wasm build, `make -C core/test check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)