### PR TITLE
Persist breakpoints and add go-to-address to the debugger

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,9 @@ async function main() {
 	await system.init();
 	system.running = true;
 
+	// Console access for poking at the machine while debugging
+	(window as unknown as { minimon: Minimon }).minimon = system;
+
 	createRoot(document.querySelector(".container")!).render(
 		<BlueprintProvider>
 			<SystemContext.Provider value={system}>

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -137,10 +137,18 @@ export class Minimon {
 
 		window.localStorage.setItem(`${this._name}-eeprom`, encoded);
 		window.localStorage.setItem(`${this._name}-rtc`, JSON.stringify({ prescale, running, value, timestamp: +Date.now() }));
+		window.localStorage.setItem(`${this._name}-breakpoints`, JSON.stringify([...this.breakpoints]));
 	}
 
 	restore(): void {
 		if (!this.state) return;
+
+		try {
+			const breakpoints = JSON.parse(window.localStorage.getItem(`${this._name}-breakpoints`) ?? "[]");
+			this.breakpoints = new Set(breakpoints.filter((v: unknown) => typeof v === "number"));
+		} catch (e) {
+			console.log("Could not restore breakpoints");
+		}
 
 		try {
 			const encoded = window.localStorage.getItem(`${this._name}-eeprom`)!;

--- a/src/ui/debugger/index.tsx
+++ b/src/ui/debugger/index.tsx
@@ -17,7 +17,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Button, ButtonGroup, HTMLSelect, Switch } from "@blueprintjs/core";
+import { Button, ButtonGroup, HTMLSelect, InputGroup, Switch } from "@blueprintjs/core";
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 import classes from "./style.module.less";
@@ -121,13 +121,37 @@ export default function Debugger() {
 		}
 	}, [followPC, pcLine, virtualizer]);
 
-	function toggleBreakpoint(line: DocumentLine) {
-		if (line.kind !== 'code') return;
+	function goTo(text: string) {
+		const address = parseInt(text.trim().replace(/^0x/i, "").replace(/h$/i, ""), 16);
+		if (isNaN(address) || address < 0 || address > 0xFFFF) return;
 
-		if (system.breakpoints.has(line.physical)) {
-			system.breakpoints.delete(line.physical);
-		} else {
+		// A manual jump means the user wants to look around
+		setFollowPC(false);
+		// Rows are fixed-height, so the offset is exact (scrollToIndex
+		// works from estimates and can land a row short)
+		virtualizer.scrollToOffset(doc.lineAt(address) * ROW_HEIGHT);
+	}
+
+	// A line carries a marker if any of its bytes has a breakpoint —
+	// notably, halting at a breakpoint prevents that byte from being
+	// classified as code, so the marker must show on hex rows too
+	function lineBreakpoints(line: DocumentLine): number[] {
+		const hits = [];
+		for (let i = 0; i < line.length; i++) {
+			if (system.breakpoints.has(line.physical + i)) hits.push(line.physical + i);
+		}
+		return hits;
+	}
+
+	function toggleBreakpoint(line: DocumentLine) {
+		const existing = lineBreakpoints(line);
+
+		if (existing.length) {
+			for (const address of existing) system.breakpoints.delete(address);
+		} else if (line.kind === 'code') {
 			system.breakpoints.add(line.physical);
+		} else {
+			return;
 		}
 
 		system.update();
@@ -164,6 +188,14 @@ export default function Debugger() {
 					className={classes.follow}
 					onChange={(e) => setFollowPC(e.currentTarget.checked)}
 				/>
+
+				<InputGroup
+					placeholder="Go to…"
+					className={classes.goto}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') goTo(e.currentTarget.value);
+					}}
+				/>
 			</div>
 
 			<div ref={scroller} className={classes.listing}>
@@ -187,7 +219,7 @@ export default function Debugger() {
 									document={doc}
 									line={line}
 									atPC={row.index === pcLine}
-									hasBreakpoint={line.kind === 'code' && system.breakpoints.has(line.physical)}
+									hasBreakpoint={lineBreakpoints(line).length > 0}
 									onToggleBreakpoint={toggleBreakpoint}
 								/>
 							</div>

--- a/src/ui/debugger/style.module.less
+++ b/src/ui/debugger/style.module.less
@@ -21,6 +21,12 @@
 	margin: 0;
 }
 
+.goto {
+	width: 10ch;
+	margin-left: auto;
+	font-family: 'Roboto Mono', monospace;
+}
+
 .listing {
 	flex: 1;
 	overflow-y: auto;


### PR DESCRIPTION
## Summary

Debugger follow-ups from the rewrite:

- **Breakpoints persist** across reloads via the existing `preserve()`/`restore()` localStorage path (alongside EEPROM/RTC)
- **Found & fixed a chicken-and-egg flaw** that persistence surfaced: halting at a breakpoint stops the CPU *before* the instruction executes, so on a fresh classification map the breakpoint's own byte never becomes code — and markers only rendered on code lines. The breakpoints that fire are exactly the ones that were invisible. Markers now render on any line whose byte range contains a breakpoint; double-click clears from any marked line, setting stays code-line-only per the spec
- **Go-to-address** in the toolbar (hex; `0x`/`h` decorations accepted): jumping unfollows the PC and scrolls by exact offset (fixed-height rows; `scrollToIndex` estimates can land a row short)
- `window.minimon` exposes the system instance for console debugging

## Verification

Headless, in-context reloads:
- Set breakpoint → reload → marker present (`live: [3388]` restored, `●` rendered on the halted-at row even though it classifies as hex)
- Double-click a marked hex row clears it; code-row toggling unchanged
- `goto 0000` → unfollows, scrollTop 0, first row `0000`; `goto 0x2100` lands the target in view while running
- `npm run check` + `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)