### PR TITLE
Pace the emulation loop with requestAnimationFrame

### DIFF
--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -94,7 +94,7 @@ export class Minimon {
 	private _inputState: number;
 	private _audio: Audio;
 	private _running = false;
-	private _timer: ReturnType<typeof setInterval> | undefined;
+	private _animation: number | undefined;
 	private _exports!: CoreExports;
 	private _cpu_state!: number;
 	private _machineBytes!: Uint8Array;
@@ -238,12 +238,16 @@ export class Minimon {
 	set running(v: boolean) {
 		if (this._running == v) return;
 
-		let time = Date.now();
+		// The loop is paced by the display: one advance per animation
+		// frame, sized by the elapsed time (capped so a long stall —
+		// or returning from a hidden tab, where rAF pauses entirely —
+		// skips ahead instead of fast-forwarding the machine)
+		let time = performance.now();
 
 		const _tick = () => {
 			if (!this._running) return;
 
-			const now = Date.now();
+			const now = performance.now();
 			const delta = Math.floor(Math.min(200, now - time) * CPU_FREQ / 1000);
 
 			time = now;
@@ -262,7 +266,13 @@ export class Minimon {
 			} else {
 				this._exports.cpu_advance(this._cpu_state, delta);
 			}
+
 			this.update();
+
+			// A breakpoint hit flips running mid-tick; don't reschedule
+			if (this._running) {
+				this._animation = requestAnimationFrame(_tick);
+			}
 		};
 
 		this._running = v;
@@ -271,9 +281,10 @@ export class Minimon {
 			// Usually reached from a click (settings toggle), which is a
 			// valid gesture to lift the autoplay suspension
 			this._audio.resume();
-			this._timer = setInterval(_tick, 0);
-		} else {
-			clearInterval(this._timer);
+			this._animation = requestAnimationFrame(_tick);
+		} else if (this._animation !== undefined) {
+			cancelAnimationFrame(this._animation);
+			this._animation = undefined;
 		}
 
 		this.update();


### PR DESCRIPTION
## Summary

The last Track C infrastructure item: the running loop fired from `setInterval(0)` — as fast as the event loop allows (many sub-frame advances per displayed frame), and background-tab throttling degraded it to ~1Hz lurches of 200ms-clamped catch-up. Now:

- **One advance per animation frame** — the natural cadence, since UI notifications were already rAF-coalesced and the audio worklet buffers ~93ms
- **`performance.now()` deltas** — monotonic, immune to wall-clock adjustments
- **Hidden tabs pause cleanly** (rAF stops) instead of lurching; the existing 200ms delta cap turns the return into a small skip
- Breakpoint hits mid-tick no longer schedule a trailing no-op frame

## Verification

Headless, via `window.minimon`:
- **Real-time pacing exact**: 3.00 wall seconds → RTC prescaler advanced exactly `3 × 0x8000` ticks = 3.00 emulated seconds (ratio 1.000)
- Stop halts (PC frozen over 400ms), resume continues (RTC advances), breakpoint halts the loop with `running=false`
- Update notifications: **exactly 60.0/s** (display refresh), previously unbounded
- `npm run check` + `vite build` clean

Amusing footnote from verification: the core's `CPU_SPEED = 1,000,000` constant is a misnomer — `cpu_advance(CPU_SPEED)` advances a *quarter* of a machine second (the harness's per-line "seconds" are 250ms of emulated time). Pre-existing, cosmetic, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)